### PR TITLE
Efalcioni - MAJ et ajout fichiers tests LRM - RS-EDA - 0.5 preprod

### DIFF
--- a/src/main/resources/sample/examples/RS-EDA/RS-EDA-usecase-AppelLimitrophe-2.json
+++ b/src/main/resources/sample/examples/RS-EDA/RS-EDA-usecase-AppelLimitrophe-2.json
@@ -1,6 +1,6 @@
 {
   "createCaseHealth": {
-    "caseId": "fr.health.samu950-DRFR159502401000233",
+    "caseId": "fr.health.samu950.DRFR159502401000233",
     "senderCaseId": "DRFR159502401000233",
     "creation": "2024-01-10T14:07:00+01:00",
     "referenceVersion": "1.4",
@@ -60,7 +60,7 @@
       }
     },
     "initialAlert": {
-      "id": "fr.health.samu950-DRFR159502401000233",
+      "id": "fr.health.samu950.DRFR159502401000233",
       "reception": "2024-01-10T14:05:00+01:00",
       "reporting": "STANDARD",
       "caller": {
@@ -125,7 +125,7 @@
             "sex": "FEM"
           }
         },
-        "id": "fr.health.samu950-DRFR159502401000233.P1"
+        "id": "fr.health.samu950.DRFR159502401000233.P1"
       }
     ],
     "perimeter": "AMU",

--- a/src/main/resources/sample/examples/RS-EDA/RS-EDA-usecase-PartageDossier-1.json
+++ b/src/main/resources/sample/examples/RS-EDA/RS-EDA-usecase-PartageDossier-1.json
@@ -38,7 +38,7 @@
         "inseeCode": "77360"
       },
       "country": "FR",
-      "freetext": "La porte de garage est ouverte",
+      "freetext": "aller directement dans le garage, la porte est ouverte",
       "geometry": {
         "point": {
           "coord": {

--- a/src/main/resources/sample/examples/RS-EDA/RS-EDA-usecase-PartageDossier-1.json
+++ b/src/main/resources/sample/examples/RS-EDA/RS-EDA-usecase-PartageDossier-1.json
@@ -1,6 +1,6 @@
 {
   "createCaseHealth": {
-    "caseId": "fr.health.samu770-DRFR157702400400055",
+    "caseId": "fr.health.samu770.DRFR157702400400055",
     "senderCaseId": "DRFR157702400400055",
     "creation": "2024-01-04T15:07:00+01:00",
     "referenceVersion": "1.3",
@@ -51,7 +51,7 @@
       }
     },
     "initialAlert": {
-      "id": "fr.health.samu770-DRFR157702400400055",
+      "id": "fr.health.samu770.DRFR157702400400055",
       "reception": "2024-01-04T15:00:00+01:00",
       "reporting": "STANDARD",
       "caller": {
@@ -110,7 +110,7 @@
             "sex": "MASC"
           }
         },
-        "id": "fr.health.samu770-DRFR157702400400055.P167"
+        "id": "fr.health.samu770.DRFR157702400400055.P167"
       }
     ],
     "perimeter": "AMU",

--- a/src/main/resources/sample/examples/RS-EDA/RS-EDA-usecase-PartageDossier-2.json
+++ b/src/main/resources/sample/examples/RS-EDA/RS-EDA-usecase-PartageDossier-2.json
@@ -1,6 +1,6 @@
 {
   "createCaseHealth": {
-    "caseId": "fr.health.samu950-DRFR159502400400159",
+    "caseId": "fr.health.samu950.DRFR159502400400159",
     "creation": "2024-01-18T15:00:00+01:00",
     "referenceVersion": "1.4",
     "qualification": {
@@ -122,7 +122,7 @@
             "sex": "FEM"
           }
         },
-        "id": "fr.health.samu950-DRFR159502400400159.P1"
+        "id": "fr.health.samu950.DRFR159502400400159.P1"
       }
     ]
   }

--- a/src/main/resources/sample/examples/RS-EDA/RS-EDA-usecase-PartageDossier-2.json
+++ b/src/main/resources/sample/examples/RS-EDA/RS-EDA-usecase-PartageDossier-2.json
@@ -1,0 +1,129 @@
+{
+  "createCaseHealth": {
+    "caseId": "fr.health.samu950-DRFR159502400400159",
+    "creation": "2024-01-18T15:00:00+01:00",
+    "referenceVersion": "1.4",
+    "qualification": {
+      "whatsHappen": {
+        "code": "C02.08.02",
+        "label": "Atteinte aux personnes ; Traumatisme / Accident ; Accident domestique"
+      },
+      "locationKind": {
+        "code": "L01.02.10",
+        "label": "Domicile ; Lieu d'habitation collectif ou foyer d'hébergement ;  escaliers"
+      },
+      "healthMotive": {
+        "code": "M02.07",
+        "label": "Traumatisme sérieux, plaie intermédiaire"
+      },
+      "details": {
+        "priority": "P2",
+        "attribution": "MU"
+      }
+    },
+    "location": {
+      "locID": "567op03a-3qr4-5st6-7uv8-109u8765432",
+      "detailedAddress": {
+        "complete": "4 rue Danielle Mitterrand",
+        "number": "4",
+        "wayName": {
+          "complete": "rue Danielle Mitterrand",
+          "type": "rue",
+          "name": "Danielle Mitterrand"
+        }
+      },
+      "city": {
+        "name": "Bezons",
+        "inseeCode": "95063"
+      },
+      "country": "FR",
+      "freetext": "dans la cage d’escalier B",
+      "geometry": {
+        "point": {
+          "coord": {
+            "lat": 48.92399978637695,
+            "lon": 2.2162439823150635,
+            "precision": "ADDRESS"
+          }
+        },
+        "obsDatime": "2024-01-04T00:05:00+01:00"
+      },
+      "access": {
+        "accessCode": [
+          "5678"
+        ],
+        "floor": "3",
+        "interphone": "Halimi",
+        "elevator": "ESC B",
+        "buildingName": "A"
+      }
+    },
+    "initialAlert": {
+      "id": "ALRT-2024-ZGY594",
+      "reception": "2024-01-04T15:00:00+01:00",
+      "reporting": "STANDARD",
+      "caller": {
+        "callerContact": {
+          "type": "PHNADD",
+          "detail": "0702880946",
+          "channel": "Personne"
+        },
+        "callbackContact": {
+          "type": "PHNADD",
+          "detail": "0702880946",
+          "channel": "Personne"
+        },
+        "language": "FR",
+        "detailedName": {
+          "complete": "Amina BERTRAND  ",
+          "lastName": "BERTRAND  ",
+          "firstName": "Amina"
+        },
+        "type": "TIERS"
+      },
+      "callTaker": {
+        "organization": "fr.health.samu950",
+        "controlRoom": "CRRA 95",
+        "calltakerContact": {
+          "type": "PHNADD",
+          "detail": "0112345678",
+          "channel": "Personne"
+        }
+      },
+      "notes": [
+        {
+          "freetext": "Entorse de la cheville, avec possible fracture. ",
+          "creation": "2024-01-18T15:02:00+01:00"
+        },
+        {
+          "freetext": "Cheville gonflée et douloureuse",
+          "creation": "2024-01-18T15:05:00+01:00"
+        },
+        {
+          "freetext": "Marche impossible.",
+          "creation": "2024-01-18T15:06:00+01:00"
+        }
+      ]
+    },
+    "owner": "fr.health.samu950",
+    "patient": [
+      {
+        "detail": {
+          "age": "P10Y"
+        },
+        "identity": {
+          "nonStrictFeatures": {
+            "complete": "Lola Halimi",
+            "firstName": "Lola ",
+            "lastName": "Halimi"
+          },
+          "strictFeatures": {
+            "birthDate": "2014-03-03",
+            "sex": "FEM"
+          }
+        },
+        "id": "fr.health.samu950-DRFR159502400400159.P1"
+      }
+    ]
+  }
+}

--- a/src/main/resources/sample/examples/RS-EDA/RS-EDA-usecase-PartageDossier-3.json
+++ b/src/main/resources/sample/examples/RS-EDA/RS-EDA-usecase-PartageDossier-3.json
@@ -1,0 +1,98 @@
+{
+  "createCaseHealth": {
+    "initialAlert": {
+      "callTaker": {
+        "organization": "fr.health.samu090",
+        "controlRoom": "CRRA 09",
+        "calltakerContact": {
+          "channel": "Personne",
+          "type": "PHNADD",
+          "detail": "0102030405"
+        }
+      },
+      "caller": {
+        "detailedName": {
+          "complete": "Lucas Bernardi ",
+          "lastName": "Bernardi ",
+          "firstName": "Lucas"
+        },
+        "callbackContact": {
+          "detail": "0561964589",
+          "type": "PHNADD",
+          "channel": "Personne"
+        },
+        "callerContact": {
+          "type": "PHNADD",
+          "detail": "0632085528",
+          "channel": "Personne"
+        },
+        "language": "FR",
+        "type": "TIERS"
+      },
+      "id": "ALRT-2024-AMP697",
+      "reception": "2024-04-18T15:00:00+02:00",
+      "reporting": "STANDARD",
+      "notes": [
+        {
+          "creation": "2024-01-18T15:05:00+01:00",
+          "freetext": "Confusion, étourdissements, s’exprime difficilement. "
+        },
+        {
+          "freetext": "Client du gite voyageant seul.",
+          "creation": "2024-01-18T15:20:00+01:00"
+        }
+      ]
+    },
+    "location": {
+      "access": {
+        "phoneNumber": 561964589
+      },
+      "city": {
+        "name": "Aulus-les-Bains",
+        "inseeCode": "09029"
+      },
+      "detailedAddress": {
+        "wayName": {
+          "complete": "Rue principale",
+          "type": "Rue",
+          "name": "principale"
+        },
+        "complete": "Rue principale"
+      },
+      "locID": "654ij03a-1kl2-3mn4-5op6-210p9876543",
+      "name": "Le gite du Moulin ",
+      "country": "FR",
+      "freetext": "Maison avec la porte verte, 100 m après le lavoir"
+    },
+    "qualification": {
+      "details": {
+        "attribution": "MU",
+        "priority": "P1"
+      },
+      "healthMotive": {
+        "code": "M03.08",
+        "label": "Signes d’AVC"
+      },
+      "locationKind": {
+        "code": "L04.12.00",
+        "label": "Lieu accueillant du public ; Hébergement touristique"
+      },
+      "whatsHappen": {
+        "code": "C02.05.00",
+        "label": "Atteinte aux personnes ; Pathologie / maladie"
+      }
+    },
+    "patient": [
+      {
+        "detail": {
+          "age": "P80Y"
+        },
+        "id": "fr.health.samu009-DRFR150092400401259.P90"
+      }
+    ],
+    "caseId": "fr.health.samu009-DRFR150092400401259",
+    "creation": "2024-01-18T15:00:00+01:00",
+    "referenceVersion": "1.4",
+    "owner": "fr.health.samu009"
+  }
+}

--- a/src/main/resources/sample/examples/RS-EDA/RS-EDA-usecase-PartageDossier-3.json
+++ b/src/main/resources/sample/examples/RS-EDA/RS-EDA-usecase-PartageDossier-3.json
@@ -87,10 +87,10 @@
         "detail": {
           "age": "P80Y"
         },
-        "id": "fr.health.samu009-DRFR150092400401259.P90"
+        "id": "fr.health.samu009.DRFR150092400401259.P90"
       }
     ],
-    "caseId": "fr.health.samu009-DRFR150092400401259",
+    "caseId": "fr.health.samu009.DRFR150092400401259",
     "creation": "2024-01-18T15:00:00+01:00",
     "referenceVersion": "1.4",
     "owner": "fr.health.samu009"


### PR DESCRIPTION
Ajout de fichier tests à la 0.5 (actuellement sur preprod) pour les prochains tests éditeurs. 

**Descriptions des nouveaux fichiers :** 

**Description du test 02**

{
file: 'RS-EDA-usecase-PartageDossier-2',

icon: 'mdi-image-broken-variant',

name: 'Lola HALIMI',

caller: 'Amina BERTRAND, baby-sitter de la patient, Lola HALIMI',

context: 'Fracture de la cheville',

environment: 'Cage d'escalier d'unimmeuble résidentiel',

victims: '1 patient',

victim: 'Fille, enfant, 10 ans',

medicalSituation: 'Entorse de la cheville, avec possible fracture. Cheville gonflée et douloureuse. Marche impossible.'
}



**Description du test 03**

{
file: 'RS-EDA-usecase-PartageDossier-3',

icon: 'mdi-head-heart-outline',

name: 'Monsieur X',

caller: 'Lucas Bernardi, gérant de gite touristique',

context: 'Suspicion d'AVC ',

environment: 'Lieu accueillant du public : Le gîte du Moulin',

victims: '1 patient',

victim: 'Adulte, environ 80 ans',

medicalSituation: 'Confusion, étourdissements, s’exprime difficilement. Client du gite voyageant seul.'