### PR TITLE
feat/auto: generation of json test cases & update condition to run CI steps

### DIFF
--- a/.github/workflows/generate-model.yaml
+++ b/.github/workflows/generate-model.yaml
@@ -53,10 +53,12 @@ jobs:
 
       - name: Clean up old generated schemas
         working-directory: ./src/main/resources
+        if: steps.filter.outputs.parsing_required == 'true'
         run: find ./json-schema -type f -name '*.json' ! -name 'customContent.schema.json' ! -name 'EDXL-DE-*.schema.json' -exec rm {} +
         
       - name: Clean up old generated java classes
         working-directory: ./src/main/java/com/hubsante/model
+        if: steps.filter.outputs.parsing_required == 'true'
         # We specifically only remove FOLDERS with the exception of a couple manually created ones
         run: find . -mindepth 1 -maxdepth 1 -type d ! -name 'builders' ! -name 'config' ! -name 'custom' ! -name 'edxl' ! -name 'exception' ! -name 'report' -exec rm -r {} +
       
@@ -142,16 +144,20 @@ jobs:
 
       - name: Install node env 🏗
         uses: actions/setup-node@v4
+        if: steps.filter.outputs.parsing_required == 'true'
         with:
           node-version: 16
 
       - name: Install openapi-generator-cli
+        if: steps.filter.outputs.parsing_required == 'true'
         run: npm install -g @openapitools/openapi-generator-cli
 
       - name: Install linter
+        if: steps.filter.outputs.parsing_required == 'true'
         run: sudo apt install -y clang-format
 
       - name: Generate Java classes
+        if: steps.filter.outputs.parsing_required == 'true'
         working-directory: ./generator
         run: |
           # Iterate over each file in the ./config directory, including the entire subfolder structure
@@ -164,6 +170,7 @@ jobs:
           find ./config/ -type f | sort -n | while read -r file; do npx @openapitools/openapi-generator-cli generate -c "$file" --skip-validate-spec; done
           
       - name: Replace src/ with generated classes
+        if: steps.filter.outputs.parsing_required == 'true'
         run: |
           rm -r ./src/main/java/com/hubsante/model/rcde || true
           rm -r ./src/main/java/com/hubsante/model/cisu || true
@@ -180,19 +187,23 @@ jobs:
         run: chmod +x ./gradlew
 
       - name: Apply license
+        if: steps.filter.outputs.parsing_required == 'true'
         run: ./gradlew licenseFormat
 
       - name: Delete old xml files
+        if: steps.filter.outputs.parsing_required == 'true'
         run: |
           find ./src/main/resources/sample/examples -name "*.xml" -type f -delete
 
       - name: Generate XML files
+        if: steps.filter.outputs.parsing_required == 'true'
         run: |
           ./gradlew generateXml
         continue-on-error: true
 
       - name: Commit and push changes
         uses: stefanzweifel/git-auto-commit-action@v5
+        if: steps.filter.outputs.parsing_required == 'true'
         with:
           commit_message: ⚙️ Auto-génération des classes et des specs
 

--- a/csv_parser/auto.sh
+++ b/csv_parser/auto.sh
@@ -3,6 +3,7 @@
 # Set variables
 NOMENCLATURE_IN_FOLDER="/Users/romainfouilland/Library/CloudStorage/OneDrive-SharedLibraries-ANS/Espace Projets - Espace Programme SI-SAMU/01 - Equipe projet/07 - Innovation et prospectif/12 - Hub Santé/17 - MDD/Nomenclatures/01 - Base interne/"
 NOMENCLATURE_FOLDER="../nomenclature_parser/in/"
+TEST_CASE_SOURCES_FOLDER="./test-case-sources/"
 MODELS_IN_FILE="/Users/romainfouilland/Library/CloudStorage/OneDrive-SharedLibraries-ANS/Espace Projets - Espace Programme SI-SAMU/01 - Equipe projet/07 - Innovation et prospectif/12 - Hub Santé/17 - MDD/MDD - Hub Santé.xlsx"
 TECHNICAL_MODELS_IN_FILE="/Users/romainfouilland/Library/CloudStorage/OneDrive-SharedLibraries-ANS/Espace Projets - Espace Programme SI-SAMU/01 - Equipe projet/07 - Innovation et prospectif/12 - Hub Santé/17 - MDD/MDD TECHNICAL - Hub Santé.xlsx"
 MODELS_FILE="models/model.xlsx"
@@ -36,6 +37,17 @@ nomenclatures() {
   fi
 }
 
+# Function to check for changes in test case sources folder and run generation of test cases json
+test_cases() {
+  if git diff-index --quiet HEAD -- "$TEST_CASE_SOURCES_FOLDER"; then
+    echo "No changes in $TEST_CASE_SOURCES_FOLDER, skipping test cases generation..."
+  else
+    echo "Changes detected in $TEST_CASE_SOURCES_FOLDER, running test cases generation..."
+    /Users/romainfouilland/code/envs/all/bin/python workflow.py --stage test_case_parser || (git stash && exit 1)
+    git add .
+  fi
+}
+
 # Function to run the script
 run() {
   echo "[$DATE] Running script..." | tee -a "$LOG_FILE"
@@ -45,6 +57,7 @@ run() {
   setup
   git add ..
   nomenclatures
+  test_cases
   if git diff-index --quiet HEAD -- ..; then
     echo "No changes found, skipping commit."
   else

--- a/csv_parser/auto.sh
+++ b/csv_parser/auto.sh
@@ -11,6 +11,7 @@ TECHNICAL_MODELS_FILE="models/model-technical.xlsx"
 TRACKING_BRANCH_NAME="auto/model_tracker"
 DATE=$(date +'%y.%m.%d %H:%M')
 LOG_FILE="cron.log"
+PYTHON_CMD="/Users/romainfouilland/code/envs/all/bin/python"
 
 # Enable printing of each command
 set -x
@@ -26,24 +27,24 @@ setup() {
 }
 
 # Function to check for changes in nomenclature folder and run nomenclatures generation
-nomenclatures() {
+update_nomenclatures() {
   if git diff-index --quiet HEAD -- "$NOMENCLATURE_FOLDER"; then
     echo "No changes in $NOMENCLATURE_FOLDER, skipping nomenclatures generation..."
   else
     echo "Changes detected in $NOMENCLATURE_FOLDER, running nomenclatures generation..."
     cd ../nomenclature_parser
-    /Users/romainfouilland/code/envs/all/bin/python nomenclature_parser.py || (git stash && exit 1)
+    ${PYTHON_CMD[@]} nomenclature_parser.py || (git stash && exit 1)
     git add .
   fi
 }
 
 # Function to check for changes in test case sources folder and run generation of test cases json
-test_cases() {
+update_test_cases() {
   if git diff-index --quiet HEAD -- "$TEST_CASE_SOURCES_FOLDER"; then
     echo "No changes in $TEST_CASE_SOURCES_FOLDER, skipping test cases generation..."
   else
     echo "Changes detected in $TEST_CASE_SOURCES_FOLDER, running test cases generation..."
-    /Users/romainfouilland/code/envs/all/bin/python workflow.py --stage test_case_parser || (git stash && exit 1)
+    ${PYTHON_CMD[@]} workflow.py --stage test_case_parser || (git stash && exit 1)
     git add .
   fi
 }
@@ -56,8 +57,8 @@ run() {
   git pull --rebase
   setup
   git add ..
-  nomenclatures
-  test_cases
+  update_nomenclatures
+  update_test_cases
   if git diff-index --quiet HEAD -- ..; then
     echo "No changes found, skipping commit."
   else


### PR DESCRIPTION
Handle the generation of test cases in `auto.sh` script if changes have been made to test case sources.

All the steps that modify the files (deletion, re-creation etc ...) as well as the steps needed to setup tools for it & the commit step are now run ONLY if the filter `parsing_required` in the first step is `true`.
It fixes a bug where some classes & resources where deleted and not recreated (because the creation step was not run), the deletions commited & the test would fail because of missing resources.