### PR TITLE
fix(converter): remove base converter instanciation

### DIFF
--- a/converter/converter/conversion_strategy/health_conversion_strategy.py
+++ b/converter/converter/conversion_strategy/health_conversion_strategy.py
@@ -17,7 +17,7 @@ def health_conversion_strategy(edxl_json, source_version: str, target_version: s
         return ReferenceConverter.convert(source_version, target_version, edxl_json)
     else:
         deducted_message_type = extract_message_type_from_message_content(message_content)
-        BaseMessageConverter(deducted_message_type).raise_conversion_not_implemented_error(source_version, target_version)
+        raise ValueError(f"Version conversion from {source_version} to {target_version} for message type '{deducted_message_type}' is currently not implemented.")
 
 unwanted_keys = ["messageId", "sender", "sentAt", "kind", "status", "recipient"]
 

--- a/converter/converter/versions/base_message_converter.py
+++ b/converter/converter/versions/base_message_converter.py
@@ -88,7 +88,7 @@ class BaseMessageConverter:
 
     @classmethod
     def raise_conversion_not_implemented_error(self, source_version, target_version):
-        raise ValueError(f"Version conversion from {source_version} to {target_version} for message type '{self.message_type}' is currently not implemented.")
+        raise ValueError(f"Version conversion from {source_version} to {target_version} for message type '{self.get_message_type()}' is currently not implemented.")
 
     @classmethod
     def raise_conversion_impossible_error(self, source_version, target_version):

--- a/converter/tests/test_health_conversion_strategy.py
+++ b/converter/tests/test_health_conversion_strategy.py
@@ -1,0 +1,15 @@
+import unittest
+from converter.conversion_strategy.health_conversion_strategy import health_conversion_strategy
+
+class TestConversionStrategy(unittest.TestCase):    
+    def test_health_conversion_strategy_raise_error_when_converting_unsupported_message_type(self):
+        edxl_json = {"content": [{"jsonContent": {"embeddedJsonContent": {"message": {"notSupportedMessageType": {}}}}}]}
+        source_version = 'v1'
+        target_version = 'v2'
+
+        with self.assertRaisesRegex(ValueError, "Version conversion from v1 to v2 for message type 'notSupportedMessageType' is currently not implemented."):
+            health_conversion_strategy(edxl_json, source_version, target_version)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
<img width="930" height="235" alt="Capture d’écran 2025-07-16 à 14 31 45" src="https://github.com/user-attachments/assets/422488ab-3fc5-4c2b-a28c-2b71b51e5f1f" />
Fix de l'erreur ci-dessus relevée en cas de tentative de conversion d'un message non supportée.
La méthode lève maintenant l'erreur attendue au lieu d'un erreur technique.