### PR TITLE
chore/security : expose port 8080 instead of 80

### DIFF
--- a/web_specs/Dockerfile
+++ b/web_specs/Dockerfile
@@ -8,8 +8,20 @@ FROM --platform=linux/amd64 nginx:alpine
 # Copy the files to the nginx default document root
 COPY ./generated/ /usr/share/nginx/html
 
-# Expose port 80 to allow incoming traffic
-EXPOSE 80
+# Copy the nginx configuration file to the container
+COPY nginx.conf /usr/share/nginx/html/nginx.conf
 
-# Start the nginx web server
-CMD ["nginx", "-g", "daemon off;"]
+# Copy custom server config to use port 8080
+COPY conf.d/default.conf /etc/nginx/conf.d/default.conf
+
+# Fix permissions for nginx cache directory when running with non-root user
+RUN mkdir -p /var/cache/nginx && chown -R nginx:nginx /var/cache/nginx /usr/share/nginx/html
+
+# Expose port 8080 to allow incoming traffic
+EXPOSE 8080
+
+# Start the nginx web server with custom config (with updated pid path)
+CMD ["nginx", "-c", "/usr/share/nginx/html/nginx.conf", "-g", "daemon off;"]
+
+# Run as non-root user for better security
+USER nginx

--- a/web_specs/conf.d/default.conf
+++ b/web_specs/conf.d/default.conf
@@ -1,0 +1,44 @@
+server {
+    listen       8080;
+    listen  [::]:8080;
+    server_name  localhost;
+
+    #access_log  /var/log/nginx/host.access.log  main;
+
+    location / {
+        root   /usr/share/nginx/html;
+        index  index.html index.htm;
+    }
+
+    #error_page  404              /404.html;
+
+    # redirect server error pages to the static page /50x.html
+    #
+    error_page   500 502 503 504  /50x.html;
+    location = /50x.html {
+        root   /usr/share/nginx/html;
+    }
+
+    # proxy the PHP scripts to Apache listening on 127.0.0.1:80
+    #
+    #location ~ \.php$ {
+    #    proxy_pass   http://127.0.0.1;
+    #}
+
+    # pass the PHP scripts to FastCGI server listening on 127.0.0.1:9000
+    #
+    #location ~ \.php$ {
+    #    root           html;
+    #    fastcgi_pass   127.0.0.1:9000;
+    #    fastcgi_index  index.php;
+    #    fastcgi_param  SCRIPT_FILENAME  /scripts$fastcgi_script_name;
+    #    include        fastcgi_params;
+    #}
+
+    # deny access to .htaccess files, if Apache's document root
+    # concurs with nginx's one
+    #
+    #location ~ /\.ht {
+    #    deny  all;
+    #}
+}

--- a/web_specs/nginx.conf
+++ b/web_specs/nginx.conf
@@ -1,0 +1,31 @@
+user  nginx;
+worker_processes  auto;
+
+error_log  /var/log/nginx/error.log notice;
+pid /var/cache/nginx/nginx.pid;
+
+
+events {
+    worker_connections  1024;
+}
+
+
+http {
+    include       /etc/nginx/mime.types;
+    default_type  application/octet-stream;
+
+    log_format  main  '$remote_addr - $remote_user [$time_local] "$request" '
+                      '$status $body_bytes_sent "$http_referer" '
+                      '"$http_user_agent" "$http_x_forwarded_for"';
+
+    access_log  /var/log/nginx/access.log  main;
+
+    sendfile        on;
+    #tcp_nopush     on;
+
+    keepalive_timeout  65;
+
+    #gzip  on;
+
+    include /etc/nginx/conf.d/*.conf;
+}


### PR DESCRIPTION
Cette Pull Request introduit une configuration personnalisée de Nginx pour le module web_specs, visant à renforcer la sécurité, la maintenabilité et l’adéquation aux bonnes pratiques de production.

**Changements principaux :**

- Ajout d’un fichier de configuration principal nginx.conf et d’un bloc serveur conf.d/default.conf.

**Mise à jour du Dockerfile :**
- Copie des nouveaux fichiers de configuration dans le conteneur.
- Passage du port exposé de 80 à 8080, en cohérence avec la configuration personnalisée.
- Correction des permissions sur les répertoires utilisés par Nginx pour éviter toute élévation de privilège.
- Lancement de Nginx sous l’utilisateur non-root nginx pour une meilleure sécurité.
- Démarrage de Nginx avec le fichier de configuration personnalisé et stockage du PID dans un répertoire sécurisé.