### PR TITLE
Correction de liens brisés dans la doc

### DIFF
--- a/src/main/resources/sample/MESSAGES_SAMPLE_TOPOLOGY.md
+++ b/src/main/resources/sample/MESSAGES_SAMPLE_TOPOLOGY.md
@@ -18,11 +18,11 @@ Although, the use case contents can be deemed to be compliant themselves.
 
 
 ## Valid messages
-These messages are used for passing tests on (de)serialization ops ([EdxlHandlerTest](../../../test/java/com/hubsante/model/edxlhandler/EdxlHandlerTest.java)) and validation ([ValidatorTest](../../../test/java/com/hubsante/model/validator/ValidatorTest.java)).
+These messages are used for passing tests on (de)serialization ops ([EdxlHandlerTest](../../../test/java/com/hubsante/model/edxlhandler/EdxlHandlerTest.java)) and validation ([Validator Tests Folder](../../../test/java/com/hubsante/model/validator)).
 
 They also could be used to easily import a message for testing purposes in projects importing this library as a dependency : the [TestMessagesHelper](../../java/com/hubsante/model/TestMessagesHelper.java) comes with methods to load them as a String.
 
 ## Failing messages
-These messages are mainly used for failing tests on validation ([ValidatorTest](../../../test/java/com/hubsante/model/validator/ValidatorTest.java)).
+These messages are mainly used for failing tests on validation ([Validator Tests Folder](../../../test/java/com/hubsante/model/validator)).
 
 They also could be imported as a String, but it probably may not be useful for projects importing this library as a dependency, which could rather construct their own failing messages based on the specific errors they want to test, and then calling the [Validator](../../java/com/hubsante/model/Validator.java) methods on them.

--- a/src/main/resources/sample/MESSAGES_SAMPLE_TOPOLOGY.md
+++ b/src/main/resources/sample/MESSAGES_SAMPLE_TOPOLOGY.md
@@ -18,17 +18,11 @@ Although, the use case contents can be deemed to be compliant themselves.
 
 
 ## Valid messages
-These messages are used for passing tests on (de)serialization ops ([EdxlHandlerTest](../../../test/java/com/hubsante/model/EdxlHandlerTest.java)) and validation ([ValidatorTest](../../../test/java/com/hubsante/model/ValidatorTest.java)).
+These messages are used for passing tests on (de)serialization ops ([EdxlHandlerTest](../../../test/java/com/hubsante/model/edxlhandler/EdxlHandlerTest.java)) and validation ([ValidatorTest](../../../test/java/com/hubsante/model/validator/ValidatorTest.java)).
 
 They also could be used to easily import a message for testing purposes in projects importing this library as a dependency : the [TestMessagesHelper](../../java/com/hubsante/model/TestMessagesHelper.java) comes with methods to load them as a String.
 
 ## Failing messages
-These messages are mainly used for failing tests on validation ([ValidatorTest](../../../test/java/com/hubsante/model/ValidatorTest.java)).
+These messages are mainly used for failing tests on validation ([ValidatorTest](../../../test/java/com/hubsante/model/validator/ValidatorTest.java)).
 
 They also could be imported as a String, but it probably may not be useful for projects importing this library as a dependency, which could rather construct their own failing messages based on the specific errors they want to test, and then calling the [Validator](../../java/com/hubsante/model/Validator.java) methods on them.
-
-
-There are also some failing messages for specific cases:
-<u>*Failing deserialization*:</u>
-[unparsable-content.json](../../../../../SAMU-Hub-Sante/hub/dispatcher/src/main/resources/sample/failing/EDXL-DE/unparsable-content.json) - A passing EDXL-DE message with malformed content: an unknown property has been added.
-Deserialization should fail.


### PR DESCRIPTION
## 🔎 Détails

Correction des liens brisés dans la page de doc des fichiers exemples

## 📄 Documentation

> Ajoutez un (des) lien(s) vers la documentation si nécessaire

## 📸 Captures d'écran

| Avant | Après |
| ----- | ----- |
|       |       |

## 🔗 Ticket associé

[Asana](https://app.asana.com/1/1201445755223134/project/1211208636192452/task/1211138036646484)
