### PR TITLE
Modification du converter pour gérer le type de véhicule dans le RC-RI (sens 15-18)

### DIFF
--- a/converter/converter/cisu/resources_info/resources_info_cisu_converter.py
+++ b/converter/converter/cisu/resources_info/resources_info_cisu_converter.py
@@ -67,11 +67,22 @@ class ResourcesInfoCISUConverter(BaseCISUConverter):
         resources = get_field_value(
             output_use_case_json, ResourcesInfoCISUConstants.RESOURCE_PATH
         )
+
+        filtered_resources = []
+
         for index, resource in enumerate(resources):
             logger.debug(f"Processing resource: {resource}")
             rs_vehicle_type = get_field_value(
                 resource, ResourcesInfoCISUConstants.VEHICLE_TYPE_PATH
             )
+
+            if not cls.is_supported_vehicle_type(rs_vehicle_type):
+                logger.info(
+                    "Removing resource because vehicleType '%s' is not supported",
+                    rs_vehicle_type,
+                )
+                continue
+
             cisu_vehicle_type = cls.translate_to_cisu_vehicle_type(rs_vehicle_type)
             set_value(
                 resource,
@@ -93,7 +104,27 @@ class ResourcesInfoCISUConverter(BaseCISUConverter):
 
             delete_paths(resource, [ResourcesInfoCISUConstants.PATIENT_ID_KEY])
 
+            filtered_resources.append(resource)
+
+        if not filtered_resources:
+            raise ValueError(
+                "Could not map resources to CISU. "
+                "At least one resource must have a CISU compatible vehicleType. "
+            )
+
+        set_value(
+            output_use_case_json,
+            ResourcesInfoCISUConstants.RESOURCE_PATH,
+            filtered_resources,
+        )
+
         return cls.format_cisu_output_json(output_json, output_use_case_json)
+
+    @classmethod
+    def is_supported_vehicle_type(cls, vehicle_type: str) -> bool:
+        return vehicle_type.startswith(
+            ResourcesInfoCISUConstants.VEHICLE_TYPE_SIS
+        ) or vehicle_type.startswith(ResourcesInfoCISUConstants.VEHICLE_TYPE_SMUR)
 
     @classmethod
     def translate_to_cisu_vehicle_type(cls, rs_vehicle_type: str) -> str:

--- a/converter/converter/cisu/resources_info/resources_info_cisu_converter.py
+++ b/converter/converter/cisu/resources_info/resources_info_cisu_converter.py
@@ -68,9 +68,9 @@ class ResourcesInfoCISUConverter(BaseCISUConverter):
             output_use_case_json, ResourcesInfoCISUConstants.RESOURCE_PATH
         )
 
-        converted_resources = cls.translate_resources_to_cisu(resources)
+        converted_resources = cls.convert_resources_to_cisu(resources)
 
-        if not converted_resources:
+        if len(converted_resources) < 1:
             raise ValueError(
                 "Could not map resources to CISU. "
                 "At least one resource must have a CISU compatible vehicleType. "
@@ -85,7 +85,7 @@ class ResourcesInfoCISUConverter(BaseCISUConverter):
         return cls.format_cisu_output_json(output_json, output_use_case_json)
 
     @classmethod
-    def translate_resources_to_cisu(
+    def convert_resources_to_cisu(
         cls, resources: list[Dict[str, Any]]
     ) -> list[Dict[str, Any]]:
         converted_resources = []

--- a/converter/converter/cisu/resources_info/resources_info_cisu_converter.py
+++ b/converter/converter/cisu/resources_info/resources_info_cisu_converter.py
@@ -68,7 +68,27 @@ class ResourcesInfoCISUConverter(BaseCISUConverter):
             output_use_case_json, ResourcesInfoCISUConstants.RESOURCE_PATH
         )
 
-        filtered_resources = []
+        converted_resources = cls.translate_resources_to_cisu(resources)
+
+        if not converted_resources:
+            raise ValueError(
+                "Could not map resources to CISU. "
+                "At least one resource must have a CISU compatible vehicleType. "
+            )
+
+        set_value(
+            output_use_case_json,
+            ResourcesInfoCISUConstants.RESOURCE_PATH,
+            converted_resources,
+        )
+
+        return cls.format_cisu_output_json(output_json, output_use_case_json)
+
+    @classmethod
+    def translate_resources_to_cisu(
+        cls, resources: list[Dict[str, Any]]
+    ) -> list[Dict[str, Any]]:
+        converted_resources = []
 
         for index, resource in enumerate(resources):
             logger.debug(f"Processing resource: {resource}")
@@ -76,14 +96,11 @@ class ResourcesInfoCISUConverter(BaseCISUConverter):
                 resource, ResourcesInfoCISUConstants.VEHICLE_TYPE_PATH
             )
 
-            if not cls.is_supported_vehicle_type(rs_vehicle_type):
-                logger.info(
-                    "Removing resource because vehicleType '%s' is not supported",
-                    rs_vehicle_type,
-                )
+            cisu_vehicle_type = cls.translate_to_cisu_vehicle_type(rs_vehicle_type)
+
+            if not cisu_vehicle_type:  # if we couldn't map the vehicleType on a SIS known type, we continue to filter the whole resource out
                 continue
 
-            cisu_vehicle_type = cls.translate_to_cisu_vehicle_type(rs_vehicle_type)
             set_value(
                 resource,
                 ResourcesInfoCISUConstants.VEHICLE_TYPE_PATH,
@@ -104,38 +121,22 @@ class ResourcesInfoCISUConverter(BaseCISUConverter):
 
             delete_paths(resource, [ResourcesInfoCISUConstants.PATIENT_ID_KEY])
 
-            filtered_resources.append(resource)
+            converted_resources.append(resource)
 
-        if not filtered_resources:
-            raise ValueError(
-                "Could not map resources to CISU. "
-                "At least one resource must have a CISU compatible vehicleType. "
-            )
-
-        set_value(
-            output_use_case_json,
-            ResourcesInfoCISUConstants.RESOURCE_PATH,
-            filtered_resources,
-        )
-
-        return cls.format_cisu_output_json(output_json, output_use_case_json)
+        return converted_resources
 
     @classmethod
-    def is_supported_vehicle_type(cls, vehicle_type: str) -> bool:
-        return vehicle_type.startswith(
-            ResourcesInfoCISUConstants.VEHICLE_TYPE_SIS
-        ) or vehicle_type.startswith(ResourcesInfoCISUConstants.VEHICLE_TYPE_SMUR)
-
-    @classmethod
-    def translate_to_cisu_vehicle_type(cls, rs_vehicle_type: str) -> str:
+    def translate_to_cisu_vehicle_type(cls, rs_vehicle_type: str) -> str | None:
         if rs_vehicle_type.startswith(ResourcesInfoCISUConstants.VEHICLE_TYPE_SIS):
             return ResourcesInfoCISUConstants.VEHICLE_TYPE_SIS
-        if rs_vehicle_type.startswith(ResourcesInfoCISUConstants.VEHICLE_TYPE_SMUR):
+        elif rs_vehicle_type.startswith(ResourcesInfoCISUConstants.VEHICLE_TYPE_SMUR):
             return ResourcesInfoCISUConstants.VEHICLE_TYPE_SMUR
-        raise ValueError(
-            f"Vehicle type '{rs_vehicle_type}' cannot be mapped to a valid CISU vehicle type. "
-            f"Accepted values are: {ResourcesInfoCISUConstants.VEHICLE_TYPE_SIS}, {ResourcesInfoCISUConstants.VEHICLE_TYPE_SMUR}."
-        )
+        else:
+            logger.info(
+                "Removing resource because vehicleType '%s' is not supported",
+                rs_vehicle_type,
+            )
+            return None
 
     @classmethod
     def translate_to_rs_vehicle_type(cls, cisu_vehicle_type: str) -> str:

--- a/converter/tests/cisu/test_resources_info_converter.py
+++ b/converter/tests/cisu/test_resources_info_converter.py
@@ -11,52 +11,74 @@ from jsonschema import validate
 
 RS_RI_SCHEMA = TestHelper.load_schema("RS-RI.schema.json")
 
+usecase_files_with_empty_state = [
+    "RS-RI_FuiteDeGaz_AliceGregoireNORMAND.06.json",
+    "RS-RI_Incendie_RaymondeLECCIA.04.json",
+    "RS-RI_Secondaire_RobertVermande.03.json",
+    "RS-RI_partageRessources_LolaHalimi.03c.json",
+]
 
-def test_rs_to_cisu():
-    rc_schema_endpoint = get_file_endpoint(
-        TestConstants.V3_GITHUB_TAG, TestConstants.RC_RI_TAG
+usecase_files_with_unsupported_vehicle_type = [
+    "RS-RI_partageRessources_MonsieurX.03.json",  # contains TSU.AMB, not mappable to CISU (only SIS/SMUR allowed)
+]
+all_usecase_files = TestHelper.get_json_files(
+    TestConstants.RS_RI_TAG, tag=TestConstants.V3_GITHUB_TAG
+)
+all_file_names = [f["name"] for f in all_usecase_files]
+
+# Dictionnaire des cas d'erreur : file_name -> message attendu
+ERROR_CASES = {
+    **{
+        name: "No states found in resource, mandatory for CISU conversion."
+        for name in usecase_files_with_empty_state
+    },
+    **{
+        name: "At least one resource must have a CISU compatible vehicleType."
+        for name in usecase_files_with_unsupported_vehicle_type
+    },
+}
+
+TEST_CASES = [
+    (name, ValueError, ERROR_CASES[name]) if name in ERROR_CASES else (name, None, None)
+    for name in all_file_names
+]
+
+
+@pytest.mark.parametrize(
+    "file_name, expected_exception, expected_message",
+    TEST_CASES,
+    ids=[c[0] for c in TEST_CASES],  # rend les sorties pytest lisibles
+)
+def test_rs_to_cisu(file_name, expected_exception, expected_message):
+    """Test RS → CISU conversion for both success and expected error cases."""
+
+    usecase_file = next(f for f in all_usecase_files if f["name"] == file_name)
+
+    edxl_json = TestHelper.create_edxl_json_from_sample(
+        TestConstants.EDXL_HEALTH_TO_FIRE_ENVELOPE_PATH, usecase_file["path"]
     )
-    rc_schema = TestHelper.load_json_file_online(rc_schema_endpoint)
 
-    usecase_files = TestHelper.get_json_files(
-        TestConstants.RS_RI_TAG, tag=TestConstants.V3_GITHUB_TAG
-    )
-
-    usecase_files_with_empty_state = [
-        "RS-RI_FuiteDeGaz_AliceGregoireNORMAND.06.json",
-        "RS-RI_Incendie_RaymondeLECCIA.04.json",
-        "RS-RI_Secondaire_RobertVermande.03.json",
-        "RS-RI_partageRessources_LolaHalimi.03c.json",
-    ]
-
-    usecase_files_with_unsupported_vehicle_type = [
-        "RS-RI_partageRessources_MonsieurX.03.json",  # contains TSU.AMB, not mappable to CISU (only SIS/SMUR allowed)
-    ]
-
-    for usecase_file in usecase_files:
-        file_name = usecase_file["name"]
-        print(f"Testing conversion of {file_name}")
-        if file_name in usecase_files_with_empty_state:
-            print(f"Skipping test for {file_name} due to known empty state issue.")
-            continue
-        if file_name in usecase_files_with_unsupported_vehicle_type:
-            print(
-                f"Skipping test for {file_name} due to known unsupported vehicle type."
-            )
-            continue
-
-        edxl_json = TestHelper.create_edxl_json_from_sample(
-            TestConstants.EDXL_HEALTH_TO_FIRE_ENVELOPE_PATH, usecase_file["path"]
+    if expected_exception is None:
+        # Cas nominal
+        rc_schema_endpoint = get_file_endpoint(
+            TestConstants.V3_GITHUB_TAG,
+            TestConstants.RC_RI_TAG,
         )
-        # Perform conversion
+        rc_schema = TestHelper.load_json_file_online(rc_schema_endpoint)
+
         result = ResourcesInfoCISUConverter.from_rs_to_cisu(edxl_json)
 
-        # Extract and validate the converted message
         usecase_name = rc_schema["title"]
         converted_message = result["content"][0]["jsonContent"]["embeddedJsonContent"][
             "message"
         ][usecase_name]
+
         validate(instance=converted_message, schema=rc_schema)
+
+    else:
+        # Cas d'erreur attendu
+        with pytest.raises(expected_exception, match=expected_message):
+            ResourcesInfoCISUConverter.from_rs_to_cisu(edxl_json)
 
 
 def test_rs_to_cisu_should_delete_patient_id():

--- a/converter/tests/cisu/test_resources_info_converter.py
+++ b/converter/tests/cisu/test_resources_info_converter.py
@@ -142,6 +142,9 @@ def test_cisu_to_rs_breaking_changes():
         pytest.param("SIS.DRAGON", "SIS", id="translates SIS.DRAGON to SIS"),
         pytest.param("SMUR", "SMUR", id="translates SMUR to SMUR"),
         pytest.param("SMUR.VLM", "SMUR", id="translates SMUR.VLM to SMUR"),
+        pytest.param("AUTREVEC", None, id="AUTREVEC is not mappable to CISU"),
+        pytest.param("FSI.HELIFSI ", None, id="FSI.HELIFSI is not mappable to CISU"),
+        pytest.param("TSU.VSL", None, id="TSU.VSL is not mappable to CISU"),
     ],
 )
 def test_translate_vehicule_type_to_cisu(rs_vehicule_type, expected):
@@ -149,19 +152,6 @@ def test_translate_vehicule_type_to_cisu(rs_vehicule_type, expected):
         rs_vehicule_type
     )
     assert cisu_vehicle_type == expected
-
-
-@pytest.mark.parametrize(
-    "rs_vehicule_type",
-    [
-        pytest.param("AUTREVEC", id="AUTREVEC is not mappable to CISU"),
-        pytest.param("FSI.HELIFSI", id="FSI.HELIFSI is not mappable to CISU"),
-        pytest.param("TSU.VSL", id="TSU.VSL is not mappable to CISU"),
-    ],
-)
-def test_translate_vehicule_type_to_cisu_raises_for_unmappable(rs_vehicule_type):
-    with pytest.raises(ValueError):
-        ResourcesInfoCISUConverter.translate_to_cisu_vehicle_type(rs_vehicule_type)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## 🔎 Détails

Cette PR : 

- [x] retire les ressources pour lesquelles le champ `vehicleType` n'a pas de mapping valide dans le RC-RI
- [x] lève une erreur de conversion s'il ne reste pas au moins une ressource après l'application de ce filtre
- [x] modifie le test unitaire associé, pour ne pas filtrer les RS-RI ne respectant pas les exigences de conversion, mais au contraire tester la levée de l'erreur attendue.

Dans ce cas de figure, le contrôle se fait sur le message d'erreur attaché (cf section `Captures d'écran`).

⚠️ **Note :** J'ai choisi de passer par une boucle **for** pour peupler une liste `filtered_resources`. Il aurait été possible d'utiliser la fonction **reduce()**, mais à l'implémentation, je l'ai trouvé nettement moins lisible.


## 📸 Captures d'écran

J'ai exécuté la commande 
```bash
 uv run pytest tests/cisu/test_resources_info_converter.py -k test_rs_to_cisu
```

Tests unitaires sans filtrage des messages, avec un expected_message erroné : 
<img width="1920" height="669" alt="converter_failed_tests" src="https://github.com/user-attachments/assets/b2105f7c-85e0-4155-9059-5eeee2bf0ef2" />


Tests unitaires sans filtrage des messages, avec un expected_message conforme :
<img width="1920" height="640" alt="converter_passing_tests" src="https://github.com/user-attachments/assets/8eb0f40d-f10f-4047-9e41-e06fa7789713" />


## 🔗 Ticket associé

[15. Modification du converter pour gérer le type de véhicule dans le RC-RI](https://app.asana.com/1/1201445755223134/project/1213308665352873/task/1213501052373949)
