### PR TITLE
chore(converter): enabled usage of mongodb uri

### DIFF
--- a/converter/converter/database.py
+++ b/converter/converter/database.py
@@ -2,27 +2,37 @@ import logging
 import os
 
 from flask import Flask, current_app
-from pymongo import MongoClient, timeout
+from pymongo import MongoClient, timeout, uri_parser
 from pymongo.database import Database
 
 logger = logging.getLogger(__name__)
 
 
 def init_db(app: Flask) -> None:
-    uri = os.getenv("MONGODB_URI", "mongodb://localhost:27017")
-    db_name = os.getenv("MONGODB_DATABASE", "hubsante")
-    username = os.getenv("MONGODB_USERNAME", "hubsante_ro")
-    password = os.getenv("MONGODB_PASSWORD", "hubsante_ro")
-
-    client: MongoClient = MongoClient(
-        uri, username=username, password=password, authSource=db_name
+    uri = os.getenv(
+        "MONGODB_URI",
+        "mongodb://hubsante_ro:hubsante_ro@localhost:27017/hubsante?authSource=hubsante",
     )
+    parsed_uri = uri_parser.parse_uri(uri)
+
+    db_name = parsed_uri["database"]
+    if db_name is None:
+        logger.error("Failed to parse db_name from provided uri")
+        raise Exception("Missing db_name in uri")
+
+    username = parsed_uri["username"]
+
+    client: MongoClient = MongoClient(uri)
+
     db = client[db_name]
 
     try:
         with timeout(5):
             db.command("ping")
-            logger.info(f"Successfully connected to MongoDB using user {username}")
+            connection_message = "Successfully connected to MongoDB"
+            if username is not None:
+                connection_message = f"{connection_message} using user {username}"
+            logger.info(connection_message)
     except Exception as e:
         logger.error(f"Failed to connect to MongoDB: {e}")
         raise


### PR DESCRIPTION
## 🔎 Détails

- Ajout du support de connection à l'instance MongoDB en utilisant une URI complète (pour matcher avec la manière dont les informations sont stockées dans Vault)

## 📸 Captures d'écran

### Cas de connexion réussie 

```
❯ uv run python -m flask run --port 8080
{"timestamp": "2026-03-12 11:00:56,938", "level": "INFO", "message": "Successfully connected to MongoDB"}
 * Serving Flask app 'converter.converter'
 * Debug mode: on
{"timestamp": "2026-03-12 11:00:56,967", "level": "INFO", "message": "\u001b[31m\u001b[1mWARNING: This is a development server. Do not use it in a production deployment. Use a production WSGI server instead.\u001b[0m\n * Running on http://127.0.0.1:8080"}
{"timestamp": "2026-03-12 11:00:56,967", "level": "INFO", "message": "\u001b[33mPress CTRL+C to quit\u001b[0m"}
{"timestamp": "2026-03-12 11:00:56,968", "level": "INFO", "message": " * Restarting with stat"}
{"timestamp": "2026-03-12 11:00:57,157", "level": "INFO", "message": "Successfully connected to MongoDB using user hubsante_ro"}
{"timestamp": "2026-03-12 11:00:57,172", "level": "WARNING", "message": " * Debugger is active!"}
{"timestamp": "2026-03-12 11:00:57,190", "level": "INFO", "message": " * Debugger PIN: 266-798-449"}
{"timestamp": "2026-03-12 11:01:22,143", "level": "INFO", "message": " * Detected change in '/Users/cdidom/Work/ans-hub-sante/SAMU-Hub-Modeles/converter/converter/database.py', reloading"}
```

### Cas d'erreur avec `MONGO_URI = mongodb://hubsante_ro:hubsante_ro@localhost:27017`

```
❯ uv run python -m flask run --port 8080
{"timestamp": "2026-03-12 11:05:12,816", "level": "ERROR", "message": "Failed to parse db_name from provided uri"}
Traceback (most recent call last):
...
Exception: Missing db_name in uri
```
