### PR TITLE
feat(converter): splitter le RC-RI en RS-RI + RS-SR par ressource lors de la première réception (flux 18→15)

### DIFF
--- a/converter/converter/cisu/resources_info/resources_info_cisu_constants.py
+++ b/converter/converter/cisu/resources_info/resources_info_cisu_constants.py
@@ -3,7 +3,9 @@ class ResourcesInfoCISUConstants:
     STATE_PATH = "$.state"
     VEHICLE_TYPE_PATH = "$.vehicleType"
 
+    CASE_ID_FIELD = "caseId"
     PATIENT_ID_KEY = "patientId"
+    POSITION_KEY = "position"
 
     VEHICLE_TYPE_SIS = "SIS"
     VEHICLE_TYPE_SMUR = "SMUR"

--- a/converter/converter/cisu/resources_info/resources_info_cisu_converter.py
+++ b/converter/converter/cisu/resources_info/resources_info_cisu_converter.py
@@ -83,7 +83,9 @@ class ResourcesInfoCISUConverter(BaseCISUConverter):
             "resourceId": resource.get("resourceId"),
             "state": resource.get("state"),
         }
-        return cls._format_output_json(output_json, output_use_case_json, "resourcesStatus")
+        return cls._format_output_json(
+            output_json, output_use_case_json, "resourcesStatus"
+        )
 
     @classmethod
     def from_cisu_to_rs(cls, edxl_json: Dict[str, Any]) -> List[Dict[str, Any]]:
@@ -96,7 +98,9 @@ class ResourcesInfoCISUConverter(BaseCISUConverter):
         if not isinstance(case_id, str):
             raise ValueError(f"Missing or invalid caseId in RC-RI message: {case_id!r}")
 
-        resources = get_field_value(cisu_use_case, ResourcesInfoCISUConstants.RESOURCE_PATH)
+        resources = get_field_value(
+            cisu_use_case, ResourcesInfoCISUConstants.RESOURCE_PATH
+        )
         current_distribution_id = edxl_json.get("distributionID")
         existing_message = get_last_rc_ri_by_case_id(
             case_id, exclude_distribution_id=current_distribution_id
@@ -104,7 +108,9 @@ class ResourcesInfoCISUConverter(BaseCISUConverter):
 
         # New caseId = first reception, RS-RI + one RS-SR per resource
         if existing_message is None:
-            logger.info("New caseId %s — returning RS-RI + one RS-SR per resource.", case_id)
+            logger.info(
+                "New caseId %s — returning RS-RI + one RS-SR per resource.", case_id
+            )
             return [cls._build_rs_ri_from_cisu(edxl_json)] + [
                 cls._build_rs_sr_from_resource(edxl_json, resource, case_id)
                 for resource in resources

--- a/converter/converter/cisu/resources_info/resources_info_cisu_converter.py
+++ b/converter/converter/cisu/resources_info/resources_info_cisu_converter.py
@@ -1,4 +1,3 @@
-import copy
 import uuid
 
 from converter.cisu.base_cisu_converter import BaseCISUConverter
@@ -74,24 +73,17 @@ class ResourcesInfoCISUConverter(BaseCISUConverter):
             resource.get("resourceId"),
             case_id,
         )
-        output_json = copy.deepcopy(edxl_json)
+        output_json = cls.copy_cisu_input_content(edxl_json)
 
         # Generate a new distributionID for the RS-SR message
-        output_json["distributionID"] = f"{output_json['senderID']}_{uuid.uuid4()}"
+        output_json["distributionID"] = f"{edxl_json['senderID']}_{uuid.uuid4()}"
 
-        message = output_json["content"][0]["jsonContent"]["embeddedJsonContent"][
-            "message"
-        ]
-
-        # Drop the original CISU use-case payload
-        message.pop(cls.get_cisu_message_type(), None)
-
-        message["resourcesStatus"] = {
+        output_use_case_json = {
             "caseId": case_id,
             "resourceId": resource.get("resourceId"),
             "state": resource.get("state"),
         }
-        return output_json
+        return cls._format_output_json(output_json, output_use_case_json, "resourcesStatus")
 
     @classmethod
     def from_cisu_to_rs(cls, edxl_json: Dict[str, Any]) -> List[Dict[str, Any]]:

--- a/converter/converter/cisu/resources_info/resources_info_cisu_converter.py
+++ b/converter/converter/cisu/resources_info/resources_info_cisu_converter.py
@@ -1,9 +1,13 @@
+import copy
+import uuid
+
 from converter.cisu.base_cisu_converter import BaseCISUConverter
-from typing import Any, Dict
+from typing import Any, Dict, List
 
 from converter.cisu.resources_info.resources_info_cisu_constants import (
     ResourcesInfoCISUConstants,
 )
+from converter.repositories.message_repository import get_last_rc_ri_by_case_id
 from converter.utils import get_field_value, set_value, delete_paths
 import logging
 
@@ -20,9 +24,9 @@ class ResourcesInfoCISUConverter(BaseCISUConverter):
         return "resourcesInfoCisu"
 
     @classmethod
-    def from_cisu_to_rs(cls, edxl_json: Dict[str, Any]) -> Dict[str, Any]:
-        logger.info("Converting from CISU to RS format for Resources Info message.")
-        logger.debug(f"Message content: {edxl_json}")
+    def _build_rs_ri_from_cisu(cls, edxl_json: Dict[str, Any]) -> Dict[str, Any]:
+        """Convert a RC-RI to a RS-RI, removing the position field from each resource."""
+        logger.info("Building RS-RI from RC-RI.")
         output_json = cls.copy_cisu_input_content(edxl_json)
         output_use_case_json = cls.copy_cisu_input_use_case_content(edxl_json)
         resources = get_field_value(
@@ -55,7 +59,75 @@ class ResourcesInfoCISUConverter(BaseCISUConverter):
                 rs_vehicle_type,
             )
 
+            # RS-RI does not carry GPS position — remove it if present
+            delete_paths(resource, [ResourcesInfoCISUConstants.POSITION_KEY])
+
         return cls.format_rs_output_json(output_json, output_use_case_json)
+
+    @classmethod
+    def _build_rs_sr_from_resource(
+        cls, edxl_json: Dict[str, Any], resource: Dict[str, Any], case_id: str
+    ) -> Dict[str, Any]:
+        """Build an RS-SR from a single RC-RI resource, reusing the EDXL envelope."""
+        logger.info(
+            "Building RS-SR for resourceId=%s, caseId=%s.",
+            resource.get("resourceId"),
+            case_id,
+        )
+        output_json = copy.deepcopy(edxl_json)
+
+        # Generate a new distributionID for the RS-SR message
+        output_json["distributionID"] = str(uuid.uuid4())
+
+        message = output_json["content"][0]["jsonContent"]["embeddedJsonContent"][
+            "message"
+        ]
+
+        # Drop the original CISU use-case payload
+        message.pop(cls.get_cisu_message_type(), None)
+
+        message["resourcesStatus"] = {
+            "caseId": case_id,
+            "resourceId": resource.get("resourceId"),
+            "state": resource.get("state"),
+        }
+        return output_json
+
+    @classmethod
+    def from_cisu_to_rs(cls, edxl_json: Dict[str, Any]) -> List[Dict[str, Any]]:
+        """RC-RI → RS: always one RS-RI; on first reception also one RS-SR per resource."""
+        logger.info("Converting from CISU to RS format for Resources Info message.")
+        logger.debug(f"Message content: {edxl_json}")
+
+        cisu_use_case = cls.copy_cisu_input_use_case_content(edxl_json)
+        case_id = cisu_use_case.get(ResourcesInfoCISUConstants.CASE_ID_FIELD)
+
+        rs_ri = cls._build_rs_ri_from_cisu(edxl_json)
+
+        # Known caseId = subsequent update, RS-RI only
+        current_distribution_id = edxl_json.get("distributionID")
+        existing_message = get_last_rc_ri_by_case_id(
+            case_id, exclude_distribution_id=current_distribution_id
+        )
+        if existing_message is not None:
+            logger.info(
+                "Known caseId %s — returning RS-RI only (no RS-SR split).", case_id
+            )
+            return [rs_ri]
+
+        # New caseId = first reception, split into RS-RI + one RS-SR per resource
+        logger.info(
+            "New caseId %s — splitting into RS-RI + one RS-SR per resource.", case_id
+        )
+        resources = get_field_value(
+            cisu_use_case, ResourcesInfoCISUConstants.RESOURCE_PATH
+        )
+        messages: List[Dict[str, Any]] = [rs_ri]
+        for resource in resources:
+            rs_sr = cls._build_rs_sr_from_resource(edxl_json, resource, case_id)
+            messages.append(rs_sr)
+
+        return messages
 
     @classmethod
     def from_rs_to_cisu(cls, edxl_json: Dict[str, Any]) -> Dict[str, Any]:

--- a/converter/converter/cisu/resources_info/resources_info_cisu_converter.py
+++ b/converter/converter/cisu/resources_info/resources_info_cisu_converter.py
@@ -98,9 +98,6 @@ class ResourcesInfoCISUConverter(BaseCISUConverter):
         if not isinstance(case_id, str):
             raise ValueError(f"Missing or invalid caseId in RC-RI message: {case_id!r}")
 
-        resources = get_field_value(
-            cisu_use_case, ResourcesInfoCISUConstants.RESOURCE_PATH
-        )
         current_distribution_id = edxl_json.get("distributionID")
         existing_message = get_last_rc_ri_by_case_id(
             case_id, exclude_distribution_id=current_distribution_id
@@ -111,10 +108,16 @@ class ResourcesInfoCISUConverter(BaseCISUConverter):
             logger.info(
                 "New caseId %s — returning RS-RI + one RS-SR per resource.", case_id
             )
-            return [cls._build_rs_ri_from_cisu(edxl_json)] + [
-                cls._build_rs_sr_from_resource(edxl_json, resource, case_id)
-                for resource in resources
-            ]
+            resources = get_field_value(
+                cisu_use_case, ResourcesInfoCISUConstants.RESOURCE_PATH
+            )
+
+            converted_messages = [cls._build_rs_ri_from_cisu(edxl_json)]
+            for resource in resources:
+                converted_messages.append(
+                    cls._build_rs_sr_from_resource(edxl_json, resource, case_id)
+                )
+            return converted_messages
 
         # TODO: Known caseId = subsequent update, define what to forward
         logger.info("Known caseId %s — no message to forward.", case_id)

--- a/converter/converter/cisu/resources_info/resources_info_cisu_converter.py
+++ b/converter/converter/cisu/resources_info/resources_info_cisu_converter.py
@@ -101,6 +101,8 @@ class ResourcesInfoCISUConverter(BaseCISUConverter):
 
         cisu_use_case = cls.copy_cisu_input_use_case_content(edxl_json)
         case_id = cisu_use_case.get(ResourcesInfoCISUConstants.CASE_ID_FIELD)
+        if not isinstance(case_id, str):
+            raise ValueError(f"Missing or invalid caseId in RC-RI message: {case_id!r}")
 
         rs_ri = cls._build_rs_ri_from_cisu(edxl_json)
 

--- a/converter/converter/cisu/resources_info/resources_info_cisu_converter.py
+++ b/converter/converter/cisu/resources_info/resources_info_cisu_converter.py
@@ -77,7 +77,7 @@ class ResourcesInfoCISUConverter(BaseCISUConverter):
         output_json = copy.deepcopy(edxl_json)
 
         # Generate a new distributionID for the RS-SR message
-        output_json["distributionID"] = str(uuid.uuid4())
+        output_json["distributionID"] = f"{output_json['senderID']}_{uuid.uuid4()}"
 
         message = output_json["content"][0]["jsonContent"]["embeddedJsonContent"][
             "message"

--- a/converter/converter/cisu/resources_info/resources_info_cisu_converter.py
+++ b/converter/converter/cisu/resources_info/resources_info_cisu_converter.py
@@ -87,7 +87,7 @@ class ResourcesInfoCISUConverter(BaseCISUConverter):
 
     @classmethod
     def from_cisu_to_rs(cls, edxl_json: Dict[str, Any]) -> List[Dict[str, Any]]:
-        """RC-RI → RS: always one RS-RI; on first reception also one RS-SR per resource."""
+        """RC-RI → RS: on first reception RS-RI + one RS-SR per resource; on subsequent updates RS-SR only."""
         logger.info("Converting from CISU to RS format for Resources Info message.")
         logger.debug(f"Message content: {edxl_json}")
 
@@ -96,32 +96,23 @@ class ResourcesInfoCISUConverter(BaseCISUConverter):
         if not isinstance(case_id, str):
             raise ValueError(f"Missing or invalid caseId in RC-RI message: {case_id!r}")
 
-        rs_ri = cls._build_rs_ri_from_cisu(edxl_json)
-
-        # Known caseId = subsequent update, RS-RI only
+        resources = get_field_value(cisu_use_case, ResourcesInfoCISUConstants.RESOURCE_PATH)
         current_distribution_id = edxl_json.get("distributionID")
         existing_message = get_last_rc_ri_by_case_id(
             case_id, exclude_distribution_id=current_distribution_id
         )
-        if existing_message is not None:
-            logger.info(
-                "Known caseId %s — returning RS-RI only (no RS-SR split).", case_id
-            )
-            return [rs_ri]
 
-        # New caseId = first reception, split into RS-RI + one RS-SR per resource
-        logger.info(
-            "New caseId %s — splitting into RS-RI + one RS-SR per resource.", case_id
-        )
-        resources = get_field_value(
-            cisu_use_case, ResourcesInfoCISUConstants.RESOURCE_PATH
-        )
-        messages: List[Dict[str, Any]] = [rs_ri]
-        for resource in resources:
-            rs_sr = cls._build_rs_sr_from_resource(edxl_json, resource, case_id)
-            messages.append(rs_sr)
+        # New caseId = first reception, RS-RI + one RS-SR per resource
+        if existing_message is None:
+            logger.info("New caseId %s — returning RS-RI + one RS-SR per resource.", case_id)
+            return [cls._build_rs_ri_from_cisu(edxl_json)] + [
+                cls._build_rs_sr_from_resource(edxl_json, resource, case_id)
+                for resource in resources
+            ]
 
-        return messages
+        # TODO: Known caseId = subsequent update, define what to forward
+        logger.info("Known caseId %s — no message to forward.", case_id)
+        return []
 
     @classmethod
     def from_rs_to_cisu(cls, edxl_json: Dict[str, Any]) -> Dict[str, Any]:

--- a/converter/converter/conversion_strategy/cisu_conversion_strategy.py
+++ b/converter/converter/conversion_strategy/cisu_conversion_strategy.py
@@ -55,10 +55,15 @@ def cisu_conversion_strategy(edxl_json, source_version, target_version):
                 f"Unknown source version {source_version}. Must be: {CISUConstants.MAINTAINED_CISU_VERSION}"
             )
 
-        rc_json_message = selected_strategy.from_cisu_to_rs(edxl_json)
-        return health_conversion_strategy(
-            rc_json_message, CISUConstants.MAINTAINED_CISU_VERSION, target_version
-        )
+        rc_json_messages = selected_strategy.from_cisu_to_rs(edxl_json)
+        if not isinstance(rc_json_messages, list):
+            rc_json_messages = [rc_json_messages]
+        return [
+            health_conversion_strategy(
+                msg, CISUConstants.MAINTAINED_CISU_VERSION, target_version
+            )
+            for msg in rc_json_messages
+        ]
     else:
         raise ValueError("Invalid direction parameter")
 

--- a/converter/converter/repositories/message_repository.py
+++ b/converter/converter/repositories/message_repository.py
@@ -9,6 +9,8 @@ logger = logging.getLogger(__name__)
 
 _COLLECTION = "messages"
 
+_DISTRIBUTION_ID_PATH = ".".join(["payload", "distributionID"])
+
 _RC_RI_TYPE = "ResourcesInfoCisuWrapper"
 _RC_RI_CASE_ID_PATH = ".".join(
     [
@@ -27,6 +29,7 @@ def _get_last_by_case_id(
     case_id: str,
     message_type: str,
     case_id_path: str,
+    exclude_distribution_id: str | None = None,
 ) -> PersistedMessage | None:
     """Return the most recently persisted message of *message_type* for *case_id*, or ``None``."""
     if not isinstance(case_id, str) or not case_id:
@@ -36,7 +39,11 @@ def _get_last_by_case_id(
     logger.info("Querying last %s message for caseId=%s", message_type, case_id)
 
     collection = get_db()[_COLLECTION]
-    query = {"type": message_type, case_id_path: case_id}
+    query: dict = {"type": message_type, case_id_path: case_id}
+
+    if exclude_distribution_id:
+        query[_DISTRIBUTION_ID_PATH] = {"$ne": exclude_distribution_id}
+        logger.debug("Excluding distributionID=%s from query", exclude_distribution_id)
     try:
         document = collection.find_one(query, sort=[("arrivedAt", DESCENDING)])
     except Exception:
@@ -68,6 +75,10 @@ def _get_last_by_case_id(
         raise
 
 
-def get_last_rc_ri_by_case_id(case_id: str) -> PersistedMessage | None:
+def get_last_rc_ri_by_case_id(
+    case_id: str, exclude_distribution_id: str | None = None
+) -> PersistedMessage | None:
     """Return the most recently persisted RC-RI document for *case_id*, or ``None``."""
-    return _get_last_by_case_id(case_id, _RC_RI_TYPE, _RC_RI_CASE_ID_PATH)
+    return _get_last_by_case_id(
+        case_id, _RC_RI_TYPE, _RC_RI_CASE_ID_PATH, exclude_distribution_id
+    )

--- a/converter/tests/cisu/test_resources_info_converter.py
+++ b/converter/tests/cisu/test_resources_info_converter.py
@@ -179,21 +179,6 @@ _RC_RI_WITH_POSITION_EDXL = TestHelper.create_edxl_json_from_sample(
 _CASE_ID = "fr.health.samu800.DRFR158002421400215"
 
 
-class TestBuildRsRiFromCisu:
-    """Unit tests for _build_rs_ri_from_cisu (1-to-1 conversion helper)."""
-
-    def test_transforms_state_to_list(self):
-        """Each resource state must be wrapped in a list."""
-        result = ResourcesInfoCISUConverter._build_rs_ri_from_cisu(
-            _RC_RI_WITH_POSITION_EDXL
-        )
-        resources_info = result["content"][0]["jsonContent"]["embeddedJsonContent"][
-            "message"
-        ]["resourcesInfo"]
-        for resource in resources_info["resource"]:
-            assert isinstance(resource["state"], list)
-
-
 class TestBuildRsSrFromResource:
     """Unit tests for _build_rs_sr_from_resource."""
 
@@ -227,25 +212,23 @@ class TestBuildRsSrFromResource:
 class TestFromCisuToRs:
     """Integration-style tests for the main from_cisu_to_rs entry point."""
 
+    @pytest.fixture(autouse=True)
+    def _results(self):
+        with patch(_PATCH_TARGET, return_value=None):
+            self.results = ResourcesInfoCISUConverter.from_cisu_to_rs(
+                _RC_RI_WITH_POSITION_EDXL
+            )
+
     def test_new_case_id_returns_rs_ri_and_rs_sr_per_resource(self):
         """With an unknown caseId, must return 1 RS-RI + 1 RS-SR per resource."""
-        with patch(_PATCH_TARGET, return_value=None):
-            results = ResourcesInfoCISUConverter.from_cisu_to_rs(
-                _RC_RI_WITH_POSITION_EDXL
-            )
-
         # fixture has 2 resources → 1 RS-RI + 2 RS-SR = 3 messages
-        assert isinstance(results, list)
-        assert len(results) == 3
-
-    def test_new_case_id_remaining_messages_are_rs_sr(self):
-        """All messages after the first must be RS-SR."""
-        with patch(_PATCH_TARGET, return_value=None):
-            results = ResourcesInfoCISUConverter.from_cisu_to_rs(
-                _RC_RI_WITH_POSITION_EDXL
-            )
-
-        for rs_sr in results[1:]:
+        assert isinstance(self.results, list)
+        assert len(self.results) == 3
+        first_message = self.results[0]["content"][0]["jsonContent"][
+            "embeddedJsonContent"
+        ]["message"]
+        assert "resourcesInfo" in first_message
+        for rs_sr in self.results[1:]:
             message = rs_sr["content"][0]["jsonContent"]["embeddedJsonContent"][
                 "message"
             ]
@@ -253,23 +236,13 @@ class TestFromCisuToRs:
 
     def test_new_case_id_rs_sr_have_distinct_distribution_ids(self):
         """Every RS-SR must have a unique distributionID different from the input."""
-        with patch(_PATCH_TARGET, return_value=None):
-            results = ResourcesInfoCISUConverter.from_cisu_to_rs(
-                _RC_RI_WITH_POSITION_EDXL
-            )
-
-        dist_ids = [msg["distributionID"] for msg in results]
+        dist_ids = [msg["distributionID"] for msg in self.results]
         assert len(dist_ids) == len(set(dist_ids)), "distributionIDs must be unique"
 
     def test_new_case_id_rs_ri_has_no_position(self):
         """The RS-RI produced for a new caseId must not contain any position field."""
-        with patch(_PATCH_TARGET, return_value=None):
-            results = ResourcesInfoCISUConverter.from_cisu_to_rs(
-                _RC_RI_WITH_POSITION_EDXL
-            )
-
-        resources_info = results[0]["content"][0]["jsonContent"]["embeddedJsonContent"][
-            "message"
-        ]["resourcesInfo"]
+        resources_info = self.results[0]["content"][0]["jsonContent"][
+            "embeddedJsonContent"
+        ]["message"]["resourcesInfo"]
         for resource in resources_info["resource"]:
             assert "position" not in resource

--- a/converter/tests/cisu/test_resources_info_converter.py
+++ b/converter/tests/cisu/test_resources_info_converter.py
@@ -209,40 +209,25 @@ class TestBuildRsSrFromResource:
         assert "resourcesInfoCisu" not in message
 
 
-class TestFromCisuToRs:
-    """Integration-style tests for the main from_cisu_to_rs entry point."""
+def test_from_cisu_to_rs_new_case_id():
+    """With an unknown caseId, from_cisu_to_rs must return 1 RS-RI + 1 RS-SR per resource."""
+    with patch(_PATCH_TARGET, return_value=None):
+        results = ResourcesInfoCISUConverter.from_cisu_to_rs(_RC_RI_WITH_POSITION_EDXL)
 
-    @pytest.fixture(autouse=True)
-    def _results(self):
-        with patch(_PATCH_TARGET, return_value=None):
-            self.results = ResourcesInfoCISUConverter.from_cisu_to_rs(
-                _RC_RI_WITH_POSITION_EDXL
-            )
+    # fixture has 2 resources → 1 RS-RI + 2 RS-SR = 3 messages
+    assert isinstance(results, list), "result must be a list"
+    assert len(results) == 3, f"expected 3 messages (1 RS-RI + 2 RS-SR), got {len(results)}"
 
-    def test_new_case_id_returns_rs_ri_and_rs_sr_per_resource(self):
-        """With an unknown caseId, must return 1 RS-RI + 1 RS-SR per resource."""
-        # fixture has 2 resources → 1 RS-RI + 2 RS-SR = 3 messages
-        assert isinstance(self.results, list)
-        assert len(self.results) == 3
-        first_message = self.results[0]["content"][0]["jsonContent"][
-            "embeddedJsonContent"
-        ]["message"]
-        assert "resourcesInfo" in first_message
-        for rs_sr in self.results[1:]:
-            message = rs_sr["content"][0]["jsonContent"]["embeddedJsonContent"][
-                "message"
-            ]
-            assert "resourcesStatus" in message
+    first_message = results[0]["content"][0]["jsonContent"]["embeddedJsonContent"]["message"]
+    assert "resourcesInfo" in first_message, "first message must be a RS-RI (resourcesInfo key expected)"
 
-    def test_new_case_id_rs_sr_have_distinct_distribution_ids(self):
-        """Every RS-SR must have a unique distributionID different from the input."""
-        dist_ids = [msg["distributionID"] for msg in self.results]
-        assert len(dist_ids) == len(set(dist_ids)), "distributionIDs must be unique"
+    for i, rs_sr in enumerate(results[1:], start=1):
+        message = rs_sr["content"][0]["jsonContent"]["embeddedJsonContent"]["message"]
+        assert "resourcesStatus" in message, f"message {i} must be a RS-SR (resourcesStatus key expected)"
 
-    def test_new_case_id_rs_ri_has_no_position(self):
-        """The RS-RI produced for a new caseId must not contain any position field."""
-        resources_info = self.results[0]["content"][0]["jsonContent"][
-            "embeddedJsonContent"
-        ]["message"]["resourcesInfo"]
-        for resource in resources_info["resource"]:
-            assert "position" not in resource
+    dist_ids = [msg["distributionID"] for msg in results]
+    assert len(dist_ids) == len(set(dist_ids)), "all distributionIDs must be unique"
+
+    resources_info = results[0]["content"][0]["jsonContent"]["embeddedJsonContent"]["message"]["resourcesInfo"]
+    for resource in resources_info["resource"]:
+        assert "position" not in resource, f"RS-RI resource {resource.get('resourceId')} must not contain a position field"

--- a/converter/tests/cisu/test_resources_info_converter.py
+++ b/converter/tests/cisu/test_resources_info_converter.py
@@ -1,5 +1,5 @@
 from unittest import TestCase
-from unittest.mock import MagicMock, patch
+from unittest.mock import patch
 
 import pytest
 
@@ -273,18 +273,3 @@ class TestFromCisuToRs:
         ]["resourcesInfo"]
         for resource in resources_info["resource"]:
             assert "position" not in resource
-
-    def test_known_case_id_returns_only_rs_ri(self):
-        """With a known caseId, must return only the RS-RI (no RS-SR split)."""
-        mock_persisted = MagicMock()
-        with patch(_PATCH_TARGET, return_value=mock_persisted):
-            results = ResourcesInfoCISUConverter.from_cisu_to_rs(
-                _RC_RI_WITH_POSITION_EDXL
-            )
-
-        assert isinstance(results, list)
-        assert len(results) == 1
-        first_message = results[0]["content"][0]["jsonContent"]["embeddedJsonContent"][
-            "message"
-        ]
-        assert "resourcesInfo" in first_message

--- a/converter/tests/cisu/test_resources_info_converter.py
+++ b/converter/tests/cisu/test_resources_info_converter.py
@@ -216,18 +216,30 @@ def test_from_cisu_to_rs_new_case_id():
 
     # fixture has 2 resources → 1 RS-RI + 2 RS-SR = 3 messages
     assert isinstance(results, list), "result must be a list"
-    assert len(results) == 3, f"expected 3 messages (1 RS-RI + 2 RS-SR), got {len(results)}"
+    assert len(results) == 3, (
+        f"expected 3 messages (1 RS-RI + 2 RS-SR), got {len(results)}"
+    )
 
-    first_message = results[0]["content"][0]["jsonContent"]["embeddedJsonContent"]["message"]
-    assert "resourcesInfo" in first_message, "first message must be a RS-RI (resourcesInfo key expected)"
+    first_message = results[0]["content"][0]["jsonContent"]["embeddedJsonContent"][
+        "message"
+    ]
+    assert "resourcesInfo" in first_message, (
+        "first message must be a RS-RI (resourcesInfo key expected)"
+    )
 
     for i, rs_sr in enumerate(results[1:], start=1):
         message = rs_sr["content"][0]["jsonContent"]["embeddedJsonContent"]["message"]
-        assert "resourcesStatus" in message, f"message {i} must be a RS-SR (resourcesStatus key expected)"
+        assert "resourcesStatus" in message, (
+            f"message {i} must be a RS-SR (resourcesStatus key expected)"
+        )
 
     dist_ids = [msg["distributionID"] for msg in results]
     assert len(dist_ids) == len(set(dist_ids)), "all distributionIDs must be unique"
 
-    resources_info = results[0]["content"][0]["jsonContent"]["embeddedJsonContent"]["message"]["resourcesInfo"]
+    resources_info = results[0]["content"][0]["jsonContent"]["embeddedJsonContent"][
+        "message"
+    ]["resourcesInfo"]
     for resource in resources_info["resource"]:
-        assert "position" not in resource, f"RS-RI resource {resource.get('resourceId')} must not contain a position field"
+        assert "position" not in resource, (
+            f"RS-RI resource {resource.get('resourceId')} must not contain a position field"
+        )

--- a/converter/tests/cisu/test_resources_info_converter.py
+++ b/converter/tests/cisu/test_resources_info_converter.py
@@ -208,7 +208,9 @@ class TestBuildRsSrFromResource:
         result = ResourcesInfoCISUConverter._build_rs_sr_from_resource(
             _RC_RI_WITH_POSITION_EDXL, self._RESOURCE, _CASE_ID
         )
-        rs_sr = result["content"][0]["jsonContent"]["embeddedJsonContent"]["message"]["resourcesStatus"]
+        rs_sr = result["content"][0]["jsonContent"]["embeddedJsonContent"]["message"][
+            "resourcesStatus"
+        ]
         assert rs_sr["caseId"] == _CASE_ID
         assert rs_sr["resourceId"] == self._RESOURCE["resourceId"]
         assert rs_sr["state"] == self._RESOURCE["state"]

--- a/converter/tests/cisu/test_resources_info_converter.py
+++ b/converter/tests/cisu/test_resources_info_converter.py
@@ -1,4 +1,5 @@
 from unittest import TestCase
+from unittest.mock import MagicMock, patch
 
 import pytest
 
@@ -105,7 +106,14 @@ def test_cisu_to_rs_breaking_changes():
         TestConstants.EDXL_FIRE_TO_HEALTH_ENVELOPE_PATH,
         "tests/fixtures/RC-RI/RC-RI_V3.0_exhaustive_fill.json",
     )
-    rs_raw_message = ResourcesInfoCISUConverter.from_cisu_to_rs(cisu_raw_message)
+    with patch(
+        "converter.cisu.resources_info.resources_info_cisu_converter.get_last_rc_ri_by_case_id",
+        return_value=None,
+    ):
+        results = ResourcesInfoCISUConverter.from_cisu_to_rs(cisu_raw_message)
+
+    # from_cisu_to_rs now returns a list; first element is the RS-RI
+    rs_raw_message = results[0]
     rs_message = ResourcesInfoCISUConverter.copy_rs_input_use_case_content(
         rs_raw_message
     )
@@ -155,3 +163,126 @@ def test_translate_vehicule_type_to_rs(cisu_vehicule_type, expected):
         cisu_vehicule_type
     )
     assert rs_vehicle_type == expected
+
+
+# ---------------------------------------------------------------------------
+# RC-RI → RS (from_cisu_to_rs) — split logic
+# ---------------------------------------------------------------------------
+
+_PATCH_TARGET = "converter.cisu.resources_info.resources_info_cisu_converter.get_last_rc_ri_by_case_id"
+
+_RC_RI_WITH_POSITION_EDXL = TestHelper.create_edxl_json_from_sample(
+    TestConstants.EDXL_FIRE_TO_HEALTH_ENVELOPE_PATH,
+    "tests/fixtures/RC-RI/RC-RI_V3.0_with_position.json",
+)
+
+_CASE_ID = "fr.health.samu800.DRFR158002421400215"
+
+
+class TestBuildRsRiFromCisu:
+    """Unit tests for _build_rs_ri_from_cisu (1-to-1 conversion helper)."""
+
+    def test_transforms_state_to_list(self):
+        """Each resource state must be wrapped in a list."""
+        result = ResourcesInfoCISUConverter._build_rs_ri_from_cisu(
+            _RC_RI_WITH_POSITION_EDXL
+        )
+        resources_info = result["content"][0]["jsonContent"]["embeddedJsonContent"][
+            "message"
+        ]["resourcesInfo"]
+        for resource in resources_info["resource"]:
+            assert isinstance(resource["state"], list)
+
+
+class TestBuildRsSrFromResource:
+    """Unit tests for _build_rs_sr_from_resource."""
+
+    _RESOURCE = {
+        "resourceId": "fr.health.samu800.resource.VLM1",
+        "orgId": "fr.health.samu800",
+        "vehicleType": "SMUR",
+        "state": {"datetime": "2024-08-01T16:42:00+02:00", "status": "RET-BASE"},
+    }
+
+    def test_rs_sr_content_is_correct(self):
+        result = ResourcesInfoCISUConverter._build_rs_sr_from_resource(
+            _RC_RI_WITH_POSITION_EDXL, self._RESOURCE, _CASE_ID
+        )
+        rs_sr = result["content"][0]["jsonContent"]["embeddedJsonContent"]["message"]["resourcesStatus"]
+        assert rs_sr["caseId"] == _CASE_ID
+        assert rs_sr["resourceId"] == self._RESOURCE["resourceId"]
+        assert rs_sr["state"] == self._RESOURCE["state"]
+
+    def test_rs_sr_does_not_contain_cisu_key(self):
+        """The RS-SR message envelope must not contain the original CISU key."""
+        result = ResourcesInfoCISUConverter._build_rs_sr_from_resource(
+            _RC_RI_WITH_POSITION_EDXL, self._RESOURCE, _CASE_ID
+        )
+        message = result["content"][0]["jsonContent"]["embeddedJsonContent"]["message"]
+        assert "resourcesInfoCisu" not in message
+
+
+class TestFromCisuToRs:
+    """Integration-style tests for the main from_cisu_to_rs entry point."""
+
+    def test_new_case_id_returns_rs_ri_and_rs_sr_per_resource(self):
+        """With an unknown caseId, must return 1 RS-RI + 1 RS-SR per resource."""
+        with patch(_PATCH_TARGET, return_value=None):
+            results = ResourcesInfoCISUConverter.from_cisu_to_rs(
+                _RC_RI_WITH_POSITION_EDXL
+            )
+
+        # fixture has 2 resources → 1 RS-RI + 2 RS-SR = 3 messages
+        assert isinstance(results, list)
+        assert len(results) == 3
+
+    def test_new_case_id_remaining_messages_are_rs_sr(self):
+        """All messages after the first must be RS-SR."""
+        with patch(_PATCH_TARGET, return_value=None):
+            results = ResourcesInfoCISUConverter.from_cisu_to_rs(
+                _RC_RI_WITH_POSITION_EDXL
+            )
+
+        for rs_sr in results[1:]:
+            message = rs_sr["content"][0]["jsonContent"]["embeddedJsonContent"][
+                "message"
+            ]
+            assert "resourcesStatus" in message
+
+    def test_new_case_id_rs_sr_have_distinct_distribution_ids(self):
+        """Every RS-SR must have a unique distributionID different from the input."""
+        with patch(_PATCH_TARGET, return_value=None):
+            results = ResourcesInfoCISUConverter.from_cisu_to_rs(
+                _RC_RI_WITH_POSITION_EDXL
+            )
+
+        dist_ids = [msg["distributionID"] for msg in results]
+        assert len(dist_ids) == len(set(dist_ids)), "distributionIDs must be unique"
+
+    def test_new_case_id_rs_ri_has_no_position(self):
+        """The RS-RI produced for a new caseId must not contain any position field."""
+        with patch(_PATCH_TARGET, return_value=None):
+            results = ResourcesInfoCISUConverter.from_cisu_to_rs(
+                _RC_RI_WITH_POSITION_EDXL
+            )
+
+        resources_info = results[0]["content"][0]["jsonContent"]["embeddedJsonContent"][
+            "message"
+        ]["resourcesInfo"]
+        for resource in resources_info["resource"]:
+            assert "position" not in resource
+
+    def test_known_case_id_returns_only_rs_ri(self):
+        """With a known caseId, must return only the RS-RI (no RS-SR split)."""
+        mock_persisted = MagicMock()
+        with patch(_PATCH_TARGET, return_value=mock_persisted):
+            results = ResourcesInfoCISUConverter.from_cisu_to_rs(
+                _RC_RI_WITH_POSITION_EDXL
+            )
+
+        assert isinstance(results, list)
+        assert len(results) == 1
+        first_message = results[0]["content"][0]["jsonContent"]["embeddedJsonContent"][
+            "message"
+        ]
+        assert "resourcesInfo" in first_message

--- a/converter/tests/conversion_strategy/test_cisu_conversion_strategy.py
+++ b/converter/tests/conversion_strategy/test_cisu_conversion_strategy.py
@@ -136,7 +136,9 @@ class TestCisuConversionStrategy(unittest.TestCase):
         self, mock_health_convert_strategy, mock_repo
     ):
         """cisu_conversion_strategy must return a list when from_cisu_to_rs produces multiple messages."""
-        message_json_path = TestHelper.get_json_files(TestConstants.RC_RI_TAG)[0]["path"]
+        message_json_path = TestHelper.get_json_files(TestConstants.RC_RI_TAG)[0][
+            "path"
+        ]
         edxl_json = TestHelper.create_edxl_json_from_sample(
             TestConstants.EDXL_FIRE_TO_HEALTH_ENVELOPE_PATH, message_json_path
         )

--- a/converter/tests/conversion_strategy/test_cisu_conversion_strategy.py
+++ b/converter/tests/conversion_strategy/test_cisu_conversion_strategy.py
@@ -124,6 +124,31 @@ class TestCisuConversionStrategy(unittest.TestCase):
         mock_convert.assert_called_once()
         mock_health_convert_strategy.assert_called_once()
 
+    @patch(
+        "converter.cisu.resources_info.resources_info_cisu_converter.get_last_rc_ri_by_case_id",
+        return_value=None,
+    )
+    @patch(
+        "converter.conversion_strategy.cisu_conversion_strategy.health_conversion_strategy",
+        side_effect=lambda msg, *_: msg,
+    )
+    def test_cisu_to_rs_resources_info_returns_list(
+        self, mock_health_convert_strategy, mock_repo
+    ):
+        """cisu_conversion_strategy must return a list when from_cisu_to_rs produces multiple messages."""
+        message_json_path = TestHelper.get_json_files(TestConstants.RC_RI_TAG)[0]["path"]
+        edxl_json = TestHelper.create_edxl_json_from_sample(
+            TestConstants.EDXL_FIRE_TO_HEALTH_ENVELOPE_PATH, message_json_path
+        )
+
+        result = cisu_conversion_strategy(
+            edxl_json, CISUConstants.MAINTAINED_CISU_VERSION, "v3"
+        )
+
+        assert isinstance(result, list)
+        # health_conversion_strategy must be called once per produced message
+        assert mock_health_convert_strategy.call_count == len(result)
+
     def test_rs_to_cisu_conversion_strategy_should_raise_error_with_invalid_target_version(
         self,
     ):

--- a/converter/tests/fixtures/RC-RI/RC-RI_V3.0_with_position.json
+++ b/converter/tests/fixtures/RC-RI/RC-RI_V3.0_with_position.json
@@ -1,0 +1,34 @@
+{
+  "resourcesInfoCisu": {
+    "caseId": "fr.health.samu800.DRFR158002421400215",
+    "resource": [
+      {
+        "resourceId": "fr.health.samu800.resource.VLM1",
+        "orgId": "fr.health.samu800",
+        "vehicleType": "SMUR",
+        "name": "VLM 800-1",
+        "state": {
+          "datetime": "2024-08-01T16:42:00+02:00",
+          "status": "RET-BASE"
+        },
+        "position": {
+          "datetime": "2024-08-01T16:42:00+02:00",
+          "coord": {
+            "lat": 48.8566,
+            "lon": 2.3522
+          }
+        }
+      },
+      {
+        "resourceId": "fr.fire.sis076.cgo-076.resource.VSAV3A",
+        "orgId": "fr.fire.sdis76.cgo-076",
+        "vehicleType": "SIS",
+        "name": "VSAV 76-22D8",
+        "state": {
+          "datetime": "2024-08-01T16:40:00+02:00",
+          "status": "FINPEC"
+        }
+      }
+    ]
+  }
+}

--- a/converter/tests/repositories/test_message_repository.py
+++ b/converter/tests/repositories/test_message_repository.py
@@ -17,6 +17,8 @@ from converter.repositories.message_repository import (
 
 _CASE_ID = "fr.health.samu800.DRFR158002421400215"
 _OTHER_CASE_ID = "fr.health.samu800.OTHERUNRELATEDCASE"
+_DIST_ID_A = "fr.health.samu800.abc123"
+_DIST_ID_B = "fr.health.samu800.def456"
 _SAMPLE_PAYLOAD = json.load(
     Path("tests/fixtures/RC-RI/sample_rc_ri_payload.json").open()
 )
@@ -29,6 +31,17 @@ def _make_payload(case_id: str) -> dict:
         "resourcesInfoCisu"
     ]["caseId"] = case_id
     return payload
+
+
+def _make_doc(distribution_id: str, arrived_at: datetime) -> dict:
+    """Build a ResourcesInfoCisuWrapper document with the given distributionID."""
+    payload = copy.deepcopy(_SAMPLE_PAYLOAD)
+    payload["distributionID"] = distribution_id
+    return {
+        "type": "ResourcesInfoCisuWrapper",
+        "arrivedAt": arrived_at,
+        "payload": payload,
+    }
 
 
 @pytest.fixture
@@ -132,3 +145,41 @@ class TestGetLastRcRiByCaseId:
 
         with pytest.raises(RuntimeError, match="connection refused"):
             get_last_rc_ri_by_case_id(_CASE_ID)
+
+    # --- exclude_distribution_id ---
+
+    def test_returns_none_when_only_matching_document_is_excluded(self, real_db):
+        """When the only matching document is excluded, should return None."""
+        real_db["messages"].insert_one(_make_doc(_DIST_ID_A, datetime(2024, 8, 1)))
+
+        result = get_last_rc_ri_by_case_id(_CASE_ID, exclude_distribution_id=_DIST_ID_A)
+
+        assert result is None
+
+    def test_returns_previous_when_most_recent_document_is_excluded(self, real_db):
+        """When the most recent document is excluded, should return the previous one."""
+        real_db["messages"].insert_many(
+            [
+                _make_doc(_DIST_ID_A, datetime(2024, 1, 1)),  # old
+                _make_doc(_DIST_ID_B, datetime(2024, 8, 1)),  # new
+            ]
+        )
+
+        result = get_last_rc_ri_by_case_id(_CASE_ID, exclude_distribution_id=_DIST_ID_B)
+
+        assert result is not None
+        assert result.payload["distributionID"] == _DIST_ID_A
+
+    def test_exclude_none_behaves_normally(self, real_db):
+        """Passing exclude_distribution_id=None must not filter anything."""
+        real_db["messages"].insert_many(
+            [
+                _make_doc(_DIST_ID_A, datetime(2024, 8, 1)),
+                _make_doc(_DIST_ID_B, datetime(2024, 3, 1)),
+            ]
+        )
+
+        result = get_last_rc_ri_by_case_id(_CASE_ID, exclude_distribution_id=None)
+
+        assert result is not None
+        assert result.payload["distributionID"] == _DIST_ID_A


### PR DESCRIPTION
## 🔎 Détails

Dans le cadre du flux 18→15, lorsqu'un message RC-RI est reçu pour la première fois pour un `caseId` donné, le converter doit produire non seulement un message RS-RI, mais également un message RS-SR par ressource contenue dans le RC-RI. Cette PR implémente cette logique de découpage.

**Elle comprend les changements suivants :**

- Lors de la première réception d'un RC-RI pour un caseId donné, le converter produit désormais un RS-RI + un RS-SR par ressource engagée
- Lors d'une mise à jour (même caseId déjà connu), seul le RS-RI est émis (pas de RS-SR supplémentaire)
- Les données GPS (position) présentes dans le RC-RI sont retirées du RS-RI, ce champ n'étant pas porté côté RS
- La recherche du message précédent en base exclut le message courant pour éviter de le considérer comme un antécédent
- La stratégie de conversion est adaptée pour gérer la production de plusieurs messages en sortie
- Couverture de tests mise à jour et enrichie pour couvrir les deux cas (première réception et mise à jour)

**Points d'attention :**
- Le distributionID du message source est exclu de la recherche en base pour éviter de compter le message courant comme un antécédent connu → **Car on persiste avant la conversion**
- Limite connue : si des ressources sont ajoutées ou retirées entre deux RC-RI successifs, aucun RS-SR différentiel n'est émis — ce cas est hors scope de cette PR.
- La conversion d'un RC-RI produit désormais une liste de messages en sortie au lieu d'un seul message

<details> 
<summary>🔧 Détails techniques</summary>

**Logique de split (resources_info_cisu_converter.py)**

- from_cisu_to_rs est refactorisée en deux méthodes privées :
  - _build_rs_ri_from_cisu : conversion 1-to-1 RC-RI → RS-RI (suppression du champ position incluse)
  - _build_rs_sr_from_resource : construction d'un RS-SR à partir d'une ressource individuelle, en réutilisant l'enveloppe EDXL et en générant un nouveau distributionID via uuid4
- from_cisu_to_rs retourne désormais List[Dict[str, Any]] au lieu de Dict[str, Any]

**Détection première réception vs mise à jour (message_repository.py)**

- get_last_rc_ri_by_case_id accepte un nouveau paramètre optionnel exclude_distribution_id
- Ce paramètre est passé via un filtre MongoDB $ne sur payload.distributionID, afin d'exclure le message courant de la recherche et éviter de le compter comme un antécédent connu

**Propagation vers la stratégie de conversion (cisu_conversion_strategy.py)**

- cisu_conversion_strategy itère désormais sur la liste retournée par from_cisu_to_rs et applique health_conversion_strategy sur chaque message produit

</details>

## 📄 Documentation

> Ajoutez un (des) lien(s) vers la documentation si nécessaire

## 📸 Captures d'écran

<details> 
<summary>🔧 Capture d'écran d'un envoie d'un RC-RI avec le client nexsis.sdisZ sur le vhost 15-nexsis_v1.9 depuis le lrm de test</summary>
<img width="2860" height="3870" alt="Capture d'écran d'un envoie d'un RC-RI avec le client nexsis.sdisZ sur le vhost 15-nexsis_v1.9 depuis le lrm de test" src="https://github.com/user-attachments/assets/f46a515b-8f75-4c52-8b1a-83531d00e9d5" />
</details> 

<details>
<summary>🔧 Capture d'écran  des RS-RI et RS-SR reçu par le client nexsis.sdisZ depuis le lrm de test</summary>
<img width="2860" height="8320" alt="Capture d'écran  des RS-RI et RS-SR reçu par le client nexsis.sdisZ depuis le lrm de test" src="https://github.com/user-attachments/assets/4d3b8376-1761-42dc-8546-7b2fd03bfeaa" />
</details> 

<details>
<summary>🔧 Capture d'écran du message RC-RI persisté dans la base mongo</summary>
<img width="1440" height="900" alt="image" src="https://github.com/user-attachments/assets/6b1b8d9e-9742-45e5-bdbb-8dfd6773ba8d" />
</details> 

## 🔗 Ticket associé

[12. Dans le converter, à la réception d’un RC-RI, si celui ci n’est pas associé à un caseId connu, le découper en un RS-RI et autant de messages RS-SR que de ressources présentes et retourner tous les messages.](https://app.asana.com/1/1201445755223134/project/1213308665352873/task/1213430827950668?focus=true)
