### PR TITLE
Dans le converter, créer une méthodes pour récupérer la donnée dans le sens 15-18

### DIFF
--- a/converter/converter/repositories/message_repository.py
+++ b/converter/converter/repositories/message_repository.py
@@ -1,6 +1,7 @@
 import logging
 
 from pymongo import DESCENDING
+from typing import Any, Mapping, Sequence
 
 from converter.database import get_db
 from converter.models.persisted_message import PersistedMessage
@@ -61,6 +62,7 @@ _RS_SR_RESOURCE_ID_PATH = ".".join(
     ]
 )
 
+
 def _get_last_by_case_id(
     case_id: str,
     message_type: str,
@@ -119,7 +121,10 @@ def get_last_rc_ri_by_case_id(
         case_id, _RC_RI_TYPE, _RC_RI_CASE_ID_PATH, exclude_distribution_id
     )
 
-def get_rs_messages_by_case_id(case_id: str) -> tuple[PersistedMessage | None, list[PersistedMessage]]:
+
+def get_rs_messages_by_case_id(
+    case_id: str,
+) -> tuple[PersistedMessage | None, list[PersistedMessage]]:
     """
     Return:
       - the most recent RS-RI message for the case
@@ -127,24 +132,24 @@ def get_rs_messages_by_case_id(case_id: str) -> tuple[PersistedMessage | None, l
     """
     if not isinstance(case_id, str) or not case_id:
         logger.warning("Invalid case_id provided: %r", case_id)
-        return []
+        return None, []
 
     rs_ri = get_last_rs_ri_by_case_id(case_id)
     rs_sr = get_last_rs_sr_by_case_id(case_id)
 
     return rs_ri, rs_sr
 
+
 def get_last_rs_ri_by_case_id(case_id: str) -> PersistedMessage | None:
     """Return the most recently persisted RS-RI document for *case_id*, or ``None``."""
-    return _get_last_by_case_id(
-        case_id, _RS_RI_TYPE, _RS_RI_CASE_ID_PATH
-    )
+    return _get_last_by_case_id(case_id, _RS_RI_TYPE, _RS_RI_CASE_ID_PATH)
+
 
 def get_last_rs_sr_by_case_id(case_id: str) -> list[PersistedMessage]:
     """Return the most recently persisted RS-SR document for each resource attached to a *case_id*."""
     collection = get_db()[_COLLECTION]
 
-    pipeline = [
+    pipeline: Sequence[Mapping[str, Any]] = [
         {
             "$match": {
                 "type": _RS_SR_TYPE,
@@ -164,9 +169,7 @@ def get_last_rs_sr_by_case_id(case_id: str) -> list[PersistedMessage]:
     try:
         documents = list(collection.aggregate(pipeline))
     except Exception:
-        logger.exception(
-            "Error querying RS-SR messages for caseId=%s", case_id
-        )
+        logger.exception("Error querying RS-SR messages for caseId=%s", case_id)
         raise
 
     rs_sr: list[PersistedMessage] = []
@@ -175,9 +178,7 @@ def get_last_rs_sr_by_case_id(case_id: str) -> list[PersistedMessage]:
         try:
             rs_sr.append(PersistedMessage.from_mongo(doc))
         except Exception:
-            logger.exception(
-                "Invalid RS-SR document (id=%s)", doc.get("_id")
-            )
+            logger.exception("Invalid RS-SR document (id=%s)", doc.get("_id"))
             raise
 
     return rs_sr

--- a/converter/converter/repositories/message_repository.py
+++ b/converter/converter/repositories/message_repository.py
@@ -12,14 +12,11 @@ _COLLECTION = "messages"
 
 _DISTRIBUTION_ID_PATH = ".".join(["payload", "distributionID"])
 
+_EDXL_BASE_PATH = "payload.content.jsonContent.embeddedJsonContent.message"
 _RC_RI_TYPE = "ResourcesInfoCisuWrapper"
 _RC_RI_CASE_ID_PATH = ".".join(
     [
-        "payload",
-        "content",
-        "jsonContent",
-        "embeddedJsonContent",
-        "message",
+        _EDXL_BASE_PATH,
         "resourcesInfoCisu",
         "caseId",
     ]
@@ -28,11 +25,7 @@ _RC_RI_CASE_ID_PATH = ".".join(
 _RS_RI_TYPE = "ResourcesInfoWrapper"
 _RS_RI_CASE_ID_PATH = ".".join(
     [
-        "payload",
-        "content",
-        "jsonContent",
-        "embeddedJsonContent",
-        "message",
+        _EDXL_BASE_PATH,
         "resourcesInfo",
         "caseId",
     ]
@@ -41,22 +34,14 @@ _RS_RI_CASE_ID_PATH = ".".join(
 _RS_SR_TYPE = "ResourcesStatusWrapper"
 _RS_SR_CASE_ID_PATH = ".".join(
     [
-        "payload",
-        "content",
-        "jsonContent",
-        "embeddedJsonContent",
-        "message",
+        _EDXL_BASE_PATH,
         "resourcesStatus",
         "caseId",
     ]
 )
 _RS_SR_RESOURCE_ID_PATH = ".".join(
     [
-        "payload",
-        "content",
-        "jsonContent",
-        "embeddedJsonContent",
-        "message",
+        _EDXL_BASE_PATH,
         "resourcesStatus",
         "resourceId",
     ]
@@ -135,7 +120,7 @@ def get_rs_messages_by_case_id(
         return None, []
 
     rs_ri = get_last_rs_ri_by_case_id(case_id)
-    rs_sr = get_last_rs_sr_by_case_id(case_id)
+    rs_sr = get_last_rs_sr_per_resource_by_case_id(case_id)
 
     return rs_ri, rs_sr
 
@@ -145,8 +130,14 @@ def get_last_rs_ri_by_case_id(case_id: str) -> PersistedMessage | None:
     return _get_last_by_case_id(case_id, _RS_RI_TYPE, _RS_RI_CASE_ID_PATH)
 
 
-def get_last_rs_sr_by_case_id(case_id: str) -> list[PersistedMessage]:
+def get_last_rs_sr_per_resource_by_case_id(
+    case_id: str,
+) -> list[PersistedMessage] | None:
     """Return the most recently persisted RS-SR document for each resource attached to a *case_id*."""
+    if not isinstance(case_id, str) or not case_id:
+        logger.warning("Invalid case_id provided: %r", case_id)
+        return None
+
     collection = get_db()[_COLLECTION]
 
     pipeline: Sequence[Mapping[str, Any]] = [

--- a/converter/converter/repositories/message_repository.py
+++ b/converter/converter/repositories/message_repository.py
@@ -132,7 +132,7 @@ def get_last_rs_ri_by_case_id(case_id: str) -> PersistedMessage | None:
 
 def get_last_rs_sr_per_resource_by_case_id(
     case_id: str,
-) -> list[PersistedMessage] | None:
+) -> list[PersistedMessage]:
     """Return the most recently persisted RS-SR document for each resource attached to a *case_id*."""
     if not isinstance(case_id, str) or not case_id:
         logger.warning("Invalid case_id provided: %r", case_id)

--- a/converter/converter/repositories/message_repository.py
+++ b/converter/converter/repositories/message_repository.py
@@ -24,6 +24,42 @@ _RC_RI_CASE_ID_PATH = ".".join(
     ]
 )
 
+_RS_RI_TYPE = "ResourcesInfoWrapper"
+_RS_RI_CASE_ID_PATH = ".".join(
+    [
+        "payload",
+        "content",
+        "jsonContent",
+        "embeddedJsonContent",
+        "message",
+        "resourcesInfo",
+        "caseId",
+    ]
+)
+
+_RS_SR_TYPE = "ResourcesStatusWrapper"
+_RS_SR_CASE_ID_PATH = ".".join(
+    [
+        "payload",
+        "content",
+        "jsonContent",
+        "embeddedJsonContent",
+        "message",
+        "resourcesStatus",
+        "caseId",
+    ]
+)
+_RS_SR_RESOURCE_ID_PATH = ".".join(
+    [
+        "payload",
+        "content",
+        "jsonContent",
+        "embeddedJsonContent",
+        "message",
+        "resourcesStatus",
+        "resourceId",
+    ]
+)
 
 def _get_last_by_case_id(
     case_id: str,
@@ -82,3 +118,66 @@ def get_last_rc_ri_by_case_id(
     return _get_last_by_case_id(
         case_id, _RC_RI_TYPE, _RC_RI_CASE_ID_PATH, exclude_distribution_id
     )
+
+def get_rs_messages_by_case_id(case_id: str) -> tuple[PersistedMessage | None, list[PersistedMessage]]:
+    """
+    Return:
+      - the most recent RS-RI message for the case
+      - the most recent RS-SR message for each resource of the case
+    """
+    if not isinstance(case_id, str) or not case_id:
+        logger.warning("Invalid case_id provided: %r", case_id)
+        return []
+
+    rs_ri = get_last_rs_ri_by_case_id(case_id)
+    rs_sr = get_last_rs_sr_by_case_id(case_id)
+
+    return rs_ri, rs_sr
+
+def get_last_rs_ri_by_case_id(case_id: str) -> PersistedMessage | None:
+    """Return the most recently persisted RS-RI document for *case_id*, or ``None``."""
+    return _get_last_by_case_id(
+        case_id, _RS_RI_TYPE, _RS_RI_CASE_ID_PATH
+    )
+
+def get_last_rs_sr_by_case_id(case_id: str) -> list[PersistedMessage]:
+    """Return the most recently persisted RS-SR document for each resource attached to a *case_id*."""
+    collection = get_db()[_COLLECTION]
+
+    pipeline = [
+        {
+            "$match": {
+                "type": _RS_SR_TYPE,
+                _RS_SR_CASE_ID_PATH: case_id,
+            }
+        },
+        {"$sort": {"arrivedAt": -1}},
+        {
+            "$group": {
+                "_id": f"${_RS_SR_RESOURCE_ID_PATH}",
+                "doc": {"$first": "$$ROOT"},
+            }
+        },
+        {"$replaceRoot": {"newRoot": "$doc"}},
+    ]
+
+    try:
+        documents = list(collection.aggregate(pipeline))
+    except Exception:
+        logger.exception(
+            "Error querying RS-SR messages for caseId=%s", case_id
+        )
+        raise
+
+    rs_sr: list[PersistedMessage] = []
+
+    for doc in documents:
+        try:
+            rs_sr.append(PersistedMessage.from_mongo(doc))
+        except Exception:
+            logger.exception(
+                "Invalid RS-SR document (id=%s)", doc.get("_id")
+            )
+            raise
+
+    return rs_sr

--- a/converter/converter/repositories/message_repository.py
+++ b/converter/converter/repositories/message_repository.py
@@ -57,7 +57,7 @@ def _get_last_by_case_id(
     """Return the most recently persisted message of *message_type* for *case_id*, or ``None``."""
     if not isinstance(case_id, str) or not case_id:
         logger.warning("Invalid case_id provided: %r", case_id)
-        return None
+        raise ValueError(f"Invalid case_id: {case_id!r}")
 
     logger.info("Querying last %s message for caseId=%s", message_type, case_id)
 
@@ -117,7 +117,7 @@ def get_rs_messages_by_case_id(
     """
     if not isinstance(case_id, str) or not case_id:
         logger.warning("Invalid case_id provided: %r", case_id)
-        return None, []
+        raise ValueError(f"Invalid case_id: {case_id!r}")
 
     rs_ri = get_last_rs_ri_by_case_id(case_id)
     rs_sr = get_last_rs_sr_per_resource_by_case_id(case_id)
@@ -136,7 +136,7 @@ def get_last_rs_sr_per_resource_by_case_id(
     """Return the most recently persisted RS-SR document for each resource attached to a *case_id*."""
     if not isinstance(case_id, str) or not case_id:
         logger.warning("Invalid case_id provided: %r", case_id)
-        return None
+        raise ValueError(f"Invalid case_id: {case_id!r}")
 
     collection = get_db()[_COLLECTION]
 

--- a/converter/tests/fixtures/RS-RI/sample_rs_ri_payload.json
+++ b/converter/tests/fixtures/RS-RI/sample_rs_ri_payload.json
@@ -1,0 +1,28 @@
+{
+  "distributionID": "fr.health.samu440.abc123",
+  "content": [
+    {
+      "jsonContent": {
+        "embeddedJsonContent": {
+          "message": {
+            "resourcesInfo": {
+              "resource": [
+                {
+                  "datetime": "2024-08-01T16:40:00+02:00",
+                  "resourceId": "fr.fire.sis076.cgo-076.resource.VLM1",
+                  "vehicleType": "LIB.AUTREPRO"
+                },
+                {
+                  "datetime": "2024-08-01T16:40:00+02:00",
+                  "resourceId": "fr.fire.sis076.cgo-076.resource.VLM2",
+                  "vehicleType": "LIB.AUTREPRO"
+                }
+              ],
+              "caseId": "fr.health.samu440.DRFR154402413800236"
+            }
+          }
+        }
+      }
+    }
+  ]
+}

--- a/converter/tests/fixtures/RS-SR/sample_rs_sr_payload.json
+++ b/converter/tests/fixtures/RS-SR/sample_rs_sr_payload.json
@@ -1,0 +1,21 @@
+{
+  "distributionID": "fr.health.samu440.abc345",
+  "content": [
+    {
+      "jsonContent": {
+        "embeddedJsonContent": {
+          "message": {
+            "resourcesStatus": {
+              "caseId": "fr.health.samu440.DRFR154402413800236",
+              "resourceId": "fr.fire.sis076.cgo-076.resource.VLM1",
+              "state": {
+                "datetime": "2024-05-18T18:46:00+02:00",
+                "status": "DECISION"
+              }
+            }
+          }
+        }
+      }
+    }
+  ]
+}

--- a/converter/tests/repositories/test_message_repository.py
+++ b/converter/tests/repositories/test_message_repository.py
@@ -176,11 +176,10 @@ class TestGetLastRcRiByCaseId:
         assert result is None
 
     @pytest.mark.parametrize("bad_input", [None, ""])
-    def test_returns_none_for_invalid_case_id(self, real_db, bad_input):
+    def test_raises_error_for_invalid_case_id(self, real_db, bad_input):
         """Should return None immediately for invalid input without querying MongoDB."""
-        result = get_last_rc_ri_by_case_id(bad_input)
-
-        assert result is None
+        with pytest.raises(ValueError, match="Invalid case_id"):
+            get_last_rc_ri_by_case_id(bad_input)
 
     def test_raises_on_mongodb_error(self, mock_db):
         """Should re-raise MongoDB exceptions after logging."""
@@ -390,11 +389,10 @@ class TestGetLastRsSrByCaseId:
         assert result == []
 
     @pytest.mark.parametrize("bad_input", [None, ""])
-    def test_returns_none_for_invalid_case_id(self, real_db, bad_input):
+    def test_raises_error_for_invalid_case_id(self, real_db, bad_input):
         """Should return None immediately for invalid input without querying MongoDB."""
-        result = get_last_rs_sr_per_resource_by_case_id(bad_input)
-
-        assert result is None
+        with pytest.raises(ValueError, match="Invalid case_id"):
+            get_last_rs_sr_per_resource_by_case_id(bad_input)
 
     def test_raises_on_mongodb_error(self, mock_db):
         """Should re-raise MongoDB exceptions after logging."""

--- a/converter/tests/repositories/test_message_repository.py
+++ b/converter/tests/repositories/test_message_repository.py
@@ -13,36 +13,73 @@ import pytest
 from converter.models.persisted_message import PersistedMessage
 from converter.repositories.message_repository import (
     get_last_rc_ri_by_case_id,
+    get_last_rs_ri_by_case_id,
+    get_last_rs_sr_by_case_id,
 )
 
-_CASE_ID = "fr.health.samu800.DRFR158002421400215"
-_OTHER_CASE_ID = "fr.health.samu800.OTHERUNRELATEDCASE"
+_RC_RI_CASE_ID = "fr.health.samu800.DRFR158002421400215"
+_OTHER_RC_RI_CASE_ID = "fr.health.samu800.OTHERUNRELATEDCASE"
 _DIST_ID_A = "fr.health.samu800.abc123"
 _DIST_ID_B = "fr.health.samu800.def456"
 _RC_RI_TYPE = "ResourcesInfoCisuWrapper"
 _RC_RI_PAYLOAD = json.load(
     Path("tests/fixtures/RC-RI/sample_rc_ri_payload.json").open()
 )
+
+_RS_RI_CASE_ID = "fr.health.samu440.DRFR154402413800236"
+_OTHER_RS_RI_CASE_ID = "fr.health.samu440.OTHERUNRELATEDCASE"
+_RS_SR_RESOURCE_ID_1 = "fr.fire.sis076.cgo-076.resource.VLM1"
+_RS_SR_RESOURCE_ID_2 = "fr.fire.sis076.cgo-076.resource.VLM2"
+_RS_RI_TYPE = "ResourcesInfoWrapper"
 _RS_RI_PAYLOAD = json.load(
     Path("tests/fixtures/RS-RI/sample_rs_ri_payload.json").open()
 )
+_RS_SR_TYPE = "ResourcesStatusWrapper"
 _RS_SR_PAYLOAD = json.load(
     Path("tests/fixtures/RS-SR/sample_rs_sr_payload.json").open()
 )
 
 
-def _make_payload(case_id: str, payload) -> dict:
+def _make_rc_ri_payload(case_id: str) -> dict:
     """Build a minimal RC-RI payload with the given caseId embedded in the real nested structure."""
-    payload = copy.deepcopy(payload)
+    payload = copy.deepcopy(_RC_RI_PAYLOAD)
     payload["content"][0]["jsonContent"]["embeddedJsonContent"]["message"][
         "resourcesInfoCisu"
     ]["caseId"] = case_id
     return payload
 
 
-def _make_doc(messageType: str, distribution_id: str, arrived_at: datetime) -> dict:
-    """Build a ResourcesInfoCisuWrapper document with the given distributionID."""
-    payload = copy.deepcopy(_RC_RI_PAYLOAD)
+def _make_rs_ri_payload(case_id: str) -> dict:
+    payload = copy.deepcopy(_RS_RI_PAYLOAD)
+    payload["content"][0]["jsonContent"]["embeddedJsonContent"]["message"][
+        "resourcesInfo"
+    ]["caseId"] = case_id
+    return payload
+
+
+def _make_rs_sr_payload(
+    case_id: str, resource_id: str, status: str | None = None
+) -> dict:
+    payload = copy.deepcopy(_RS_SR_PAYLOAD)
+    resources_status = payload["content"][0]["jsonContent"]["embeddedJsonContent"][
+        "message"
+    ]["resourcesStatus"]
+
+    resources_status["caseId"] = case_id
+    resources_status["resourceId"] = resource_id
+
+    if status is not None:
+        resources_status["state"]["status"] = status
+
+    return payload
+
+
+def _make_doc(
+    payload: dict, messageType: str, distribution_id: str, arrived_at: datetime
+) -> dict:
+    """Build a document with the given payload, message type and distributionID."""
+    payload = copy.deepcopy(payload)
+    # line 82 below
     payload["distributionID"] = distribution_id
     return {
         "type": messageType,
@@ -81,7 +118,7 @@ class TestGetLastRcRiByCaseId:
             }
         )
 
-        result = get_last_rc_ri_by_case_id(_CASE_ID)
+        result = get_last_rc_ri_by_case_id(_RC_RI_CASE_ID)
 
         assert result is not None
         assert isinstance(result, PersistedMessage)
@@ -95,13 +132,12 @@ class TestGetLastRcRiByCaseId:
             {
                 "type": "ResourcesInfoCisuWrapper",
                 "arrivedAt": datetime(2024, 8, 1),
-                "payload": _make_payload(
-                    _OTHER_CASE_ID,
-                    _RC_RI_PAYLOAD,
+                "payload": _make_rc_ri_payload(
+                    _OTHER_RC_RI_CASE_ID
                 ),  # different caseId in nested path
             }
         )
-        result = get_last_rc_ri_by_case_id(_CASE_ID)
+        result = get_last_rc_ri_by_case_id(_RC_RI_CASE_ID)
 
         assert result is None
 
@@ -122,7 +158,7 @@ class TestGetLastRcRiByCaseId:
             ]
         )
 
-        result = get_last_rc_ri_by_case_id(_CASE_ID)
+        result = get_last_rc_ri_by_case_id(_RC_RI_CASE_ID)
 
         assert result.arrived_at == datetime(2024, 8, 1)
 
@@ -136,7 +172,7 @@ class TestGetLastRcRiByCaseId:
             }
         )
 
-        result = get_last_rc_ri_by_case_id(_CASE_ID)
+        result = get_last_rc_ri_by_case_id(_RC_RI_CASE_ID)
 
         assert result is None
 
@@ -152,15 +188,19 @@ class TestGetLastRcRiByCaseId:
         mock_db["messages"].find_one.side_effect = RuntimeError("connection refused")
 
         with pytest.raises(RuntimeError, match="connection refused"):
-            get_last_rc_ri_by_case_id(_CASE_ID)
+            get_last_rc_ri_by_case_id(_RC_RI_CASE_ID)
 
     # --- exclude_distribution_id ---
 
     def test_returns_none_when_only_matching_document_is_excluded(self, real_db):
         """When the only matching document is excluded, should return None."""
-        real_db["messages"].insert_one(_make_doc(_RC_RI_TYPE, _DIST_ID_A, datetime(2024, 8, 1)))
+        real_db["messages"].insert_one(
+            _make_doc(_RC_RI_PAYLOAD, _RC_RI_TYPE, _DIST_ID_A, datetime(2024, 8, 1))
+        )
 
-        result = get_last_rc_ri_by_case_id(_CASE_ID, exclude_distribution_id=_DIST_ID_A)
+        result = get_last_rc_ri_by_case_id(
+            _RC_RI_CASE_ID, exclude_distribution_id=_DIST_ID_A
+        )
 
         assert result is None
 
@@ -168,12 +208,18 @@ class TestGetLastRcRiByCaseId:
         """When the most recent document is excluded, should return the previous one."""
         real_db["messages"].insert_many(
             [
-                _make_doc(_RC_RI_TYPE, _DIST_ID_A, datetime(2024, 1, 1)),  # old
-                _make_doc(_RC_RI_TYPE, _DIST_ID_B, datetime(2024, 8, 1)),  # new
+                _make_doc(
+                    _RC_RI_PAYLOAD, _RC_RI_TYPE, _DIST_ID_A, datetime(2024, 1, 1)
+                ),  # old
+                _make_doc(
+                    _RC_RI_PAYLOAD, _RC_RI_TYPE, _DIST_ID_B, datetime(2024, 8, 1)
+                ),  # new
             ]
         )
 
-        result = get_last_rc_ri_by_case_id(_CASE_ID, exclude_distribution_id=_DIST_ID_B)
+        result = get_last_rc_ri_by_case_id(
+            _RC_RI_CASE_ID, exclude_distribution_id=_DIST_ID_B
+        )
 
         assert result is not None
         assert result.payload["distributionID"] == _DIST_ID_A
@@ -182,12 +228,178 @@ class TestGetLastRcRiByCaseId:
         """Passing exclude_distribution_id=None must not filter anything."""
         real_db["messages"].insert_many(
             [
-                _make_doc(_RC_RI_TYPE, _DIST_ID_A, datetime(2024, 8, 1)),
-                _make_doc(_RC_RI_TYPE, _DIST_ID_B, datetime(2024, 3, 1)),
+                _make_doc(
+                    _RC_RI_PAYLOAD, _RC_RI_TYPE, _DIST_ID_A, datetime(2024, 8, 1)
+                ),
+                _make_doc(
+                    _RC_RI_PAYLOAD, _RC_RI_TYPE, _DIST_ID_B, datetime(2024, 3, 1)
+                ),
             ]
         )
 
-        result = get_last_rc_ri_by_case_id(_CASE_ID, exclude_distribution_id=None)
+        result = get_last_rc_ri_by_case_id(_RC_RI_CASE_ID, exclude_distribution_id=None)
 
         assert result is not None
         assert result.payload["distributionID"] == _DIST_ID_A
+
+
+class TestGetLastRsRiByCaseId:
+    def test_returns_document_when_found(self, real_db):
+        """Should return a PersistedMessage built from the found document and conform to RS-RI schema."""
+        arrived_at = datetime(2024, 8, 1, 14, 0, 0)
+        real_db["messages"].insert_one(
+            {
+                "type": _RS_RI_TYPE,
+                "arrivedAt": arrived_at,
+                "payload": _RS_RI_PAYLOAD,
+            }
+        )
+
+        result = get_last_rs_ri_by_case_id(_RS_RI_CASE_ID)
+
+        assert result is not None
+        assert isinstance(result, PersistedMessage)
+        assert result.message_type == _RS_RI_TYPE
+        assert result.arrived_at == arrived_at
+        assert result.payload == _RS_RI_PAYLOAD
+
+    def test_returns_none_when_not_found(self, real_db):
+        """Should return None when no RS-RI document exists for the given caseId."""
+        real_db["messages"].insert_one(
+            {
+                "type": "ResourcesInfoCisuWrapper",
+                "arrivedAt": datetime(2024, 8, 1),
+                "payload": _make_rs_ri_payload(
+                    _OTHER_RS_RI_CASE_ID,
+                ),  # different caseId in nested path
+            }
+        )
+
+        result = get_last_rs_ri_by_case_id(_RS_RI_CASE_ID)
+
+        assert result is None
+
+    def test_returns_most_recent_document(self, real_db):
+        """Should return the document with the latest arrivedAt among multiple matches."""
+        real_db["messages"].insert_many(
+            [
+                {
+                    "type": _RS_RI_TYPE,
+                    "arrivedAt": datetime(2024, 1, 1),
+                    "payload": _RS_RI_PAYLOAD,
+                },
+                {
+                    "type": _RS_RI_TYPE,
+                    "arrivedAt": datetime(2024, 8, 1),  # le plus récent
+                    "payload": _RS_RI_PAYLOAD,
+                },
+            ]
+        )
+
+        result = get_last_rs_ri_by_case_id(_RS_RI_CASE_ID)
+
+        assert result.arrived_at == datetime(2024, 8, 1)
+
+
+class TestGetLastRsSrByCaseId:
+    def test_returns_documents_when_found(self, real_db):
+        """Should return a list of PersistedMessage built from the found documents and conform to RS-SR schema."""
+        rs_sr_1 = {
+            "type": _RS_SR_TYPE,
+            "arrivedAt": datetime(2024, 8, 1, 14),
+            "payload": _make_rs_sr_payload(_RS_RI_CASE_ID, _RS_SR_RESOURCE_ID_1),
+        }
+        rs_sr_2_v1 = {
+            "type": _RS_SR_TYPE,
+            "arrivedAt": datetime(2024, 8, 1, 14),
+            "payload": _make_rs_sr_payload(_RS_RI_CASE_ID, _RS_SR_RESOURCE_ID_2),
+        }
+        rs_sr_2_v2 = {
+            "type": _RS_SR_TYPE,
+            "arrivedAt": datetime(2024, 8, 1, 16),
+            "payload": _make_rs_sr_payload(
+                _RS_RI_CASE_ID, _RS_SR_RESOURCE_ID_2, status="DECLENCHE"
+            ),
+        }
+        rs_sr_2_v3 = {
+            "type": _RS_SR_TYPE,
+            "arrivedAt": datetime(2024, 8, 1, 17),
+            "payload": _make_rs_sr_payload(
+                _RS_RI_CASE_ID, _RS_SR_RESOURCE_ID_2, status="DEPART"
+            ),
+        }
+        rs_sr_2_v4 = {
+            "type": _RS_SR_TYPE,
+            "arrivedAt": datetime(2024, 8, 1, 18),
+            "payload": _make_rs_sr_payload(
+                _RS_RI_CASE_ID, _RS_SR_RESOURCE_ID_2, status="ANNULE"
+            ),
+        }
+        same_resource_other_case_rs_sr = {
+            "type": _RS_SR_TYPE,
+            "arrivedAt": datetime(2024, 8, 1, 19),
+            "payload": _make_rs_sr_payload(_OTHER_RS_RI_CASE_ID, _RS_SR_RESOURCE_ID_1),
+        }
+
+        real_db["messages"].insert_many(
+            [
+                rs_sr_1,
+                rs_sr_2_v1,
+                rs_sr_2_v2,
+                rs_sr_2_v3,
+                rs_sr_2_v4,
+                same_resource_other_case_rs_sr,
+            ]
+        )
+        result = get_last_rs_sr_by_case_id(_RS_RI_CASE_ID)
+
+        assert result is not None
+        assert isinstance(result, list)
+        assert len(result) == 2
+
+        # useful to not rely on list ordering
+        result_by_resource = {
+            item.payload["content"][0]["jsonContent"]["embeddedJsonContent"]["message"][
+                "resourcesStatus"
+            ]["resourceId"]: item
+            for item in result
+        }
+
+        # Assertions par resourceId
+        assert _RS_SR_RESOURCE_ID_1 in result_by_resource
+        assert _RS_SR_RESOURCE_ID_2 in result_by_resource
+
+        # Ressource 1 : on récupère le rs_sr correspondant au case_id (rs_sr_1),
+        # et non un plus récent correspondant un autre case_id (same_resource_other_case_rs_sr)
+        assert result_by_resource[_RS_SR_RESOURCE_ID_1].arrived_at == datetime(
+            2024, 8, 1, 14
+        )
+
+        # Ressource 2 : on récupère le rs_sr le plus récent pour la combinaison case_id / resource_id
+        assert result_by_resource[_RS_SR_RESOURCE_ID_2].arrived_at == datetime(
+            2024, 8, 1, 18
+        )
+        assert (
+            result_by_resource[_RS_SR_RESOURCE_ID_2].payload["content"][0][
+                "jsonContent"
+            ]["embeddedJsonContent"]["message"]["resourcesStatus"]["state"]["status"]
+            == "ANNULE"
+        )
+
+    def test_returns_empty_list_when_none_found(self, real_db):
+        result = get_last_rs_sr_by_case_id("nonexistent_case")
+        assert result == []
+
+    @pytest.mark.parametrize("bad_input", [None, ""])
+    def test_returns_none_for_invalid_case_id(self, real_db, bad_input):
+        """Should return None immediately for invalid input without querying MongoDB."""
+        result = get_last_rs_sr_by_case_id(bad_input)
+
+        assert result == []
+
+    def test_raises_on_mongodb_error(self, mock_db):
+        """Should re-raise MongoDB exceptions after logging."""
+        mock_db["messages"].aggregate.side_effect = RuntimeError("connection refused")
+
+        with pytest.raises(RuntimeError, match="connection refused"):
+            get_last_rs_sr_by_case_id(_RS_RI_CASE_ID)

--- a/converter/tests/repositories/test_message_repository.py
+++ b/converter/tests/repositories/test_message_repository.py
@@ -1,4 +1,4 @@
-"""Unit tests for converter.repository.get_last_rc_ri_by_case_id."""
+"""Unit tests for converter.repository methods"""
 
 from datetime import datetime
 from pathlib import Path
@@ -14,7 +14,7 @@ from converter.models.persisted_message import PersistedMessage
 from converter.repositories.message_repository import (
     get_last_rc_ri_by_case_id,
     get_last_rs_ri_by_case_id,
-    get_last_rs_sr_by_case_id,
+    get_last_rs_sr_per_resource_by_case_id,
 )
 
 _RC_RI_CASE_ID = "fr.health.samu800.DRFR158002421400215"
@@ -79,7 +79,6 @@ def _make_doc(
 ) -> dict:
     """Build a document with the given payload, message type and distributionID."""
     payload = copy.deepcopy(payload)
-    # line 82 below
     payload["distributionID"] = distribution_id
     return {
         "type": messageType,
@@ -267,7 +266,7 @@ class TestGetLastRsRiByCaseId:
         """Should return None when no RS-RI document exists for the given caseId."""
         real_db["messages"].insert_one(
             {
-                "type": "ResourcesInfoCisuWrapper",
+                "type": _RS_RI_TYPE,
                 "arrivedAt": datetime(2024, 8, 1),
                 "payload": _make_rs_ri_payload(
                     _OTHER_RS_RI_CASE_ID,
@@ -351,7 +350,7 @@ class TestGetLastRsSrByCaseId:
                 same_resource_other_case_rs_sr,
             ]
         )
-        result = get_last_rs_sr_by_case_id(_RS_RI_CASE_ID)
+        result = get_last_rs_sr_per_resource_by_case_id(_RS_RI_CASE_ID)
 
         assert result is not None
         assert isinstance(result, list)
@@ -387,19 +386,19 @@ class TestGetLastRsSrByCaseId:
         )
 
     def test_returns_empty_list_when_none_found(self, real_db):
-        result = get_last_rs_sr_by_case_id("nonexistent_case")
+        result = get_last_rs_sr_per_resource_by_case_id("nonexistent_case")
         assert result == []
 
     @pytest.mark.parametrize("bad_input", [None, ""])
     def test_returns_none_for_invalid_case_id(self, real_db, bad_input):
         """Should return None immediately for invalid input without querying MongoDB."""
-        result = get_last_rs_sr_by_case_id(bad_input)
+        result = get_last_rs_sr_per_resource_by_case_id(bad_input)
 
-        assert result == []
+        assert result is None
 
     def test_raises_on_mongodb_error(self, mock_db):
         """Should re-raise MongoDB exceptions after logging."""
         mock_db["messages"].aggregate.side_effect = RuntimeError("connection refused")
 
         with pytest.raises(RuntimeError, match="connection refused"):
-            get_last_rs_sr_by_case_id(_RS_RI_CASE_ID)
+            get_last_rs_sr_per_resource_by_case_id(_RS_RI_CASE_ID)

--- a/converter/tests/repositories/test_message_repository.py
+++ b/converter/tests/repositories/test_message_repository.py
@@ -19,26 +19,33 @@ _CASE_ID = "fr.health.samu800.DRFR158002421400215"
 _OTHER_CASE_ID = "fr.health.samu800.OTHERUNRELATEDCASE"
 _DIST_ID_A = "fr.health.samu800.abc123"
 _DIST_ID_B = "fr.health.samu800.def456"
-_SAMPLE_PAYLOAD = json.load(
+_RC_RI_TYPE = "ResourcesInfoCisuWrapper"
+_RC_RI_PAYLOAD = json.load(
     Path("tests/fixtures/RC-RI/sample_rc_ri_payload.json").open()
+)
+_RS_RI_PAYLOAD = json.load(
+    Path("tests/fixtures/RS-RI/sample_rs_ri_payload.json").open()
+)
+_RS_SR_PAYLOAD = json.load(
+    Path("tests/fixtures/RS-SR/sample_rs_sr_payload.json").open()
 )
 
 
-def _make_payload(case_id: str) -> dict:
+def _make_payload(case_id: str, payload) -> dict:
     """Build a minimal RC-RI payload with the given caseId embedded in the real nested structure."""
-    payload = copy.deepcopy(_SAMPLE_PAYLOAD)
+    payload = copy.deepcopy(payload)
     payload["content"][0]["jsonContent"]["embeddedJsonContent"]["message"][
         "resourcesInfoCisu"
     ]["caseId"] = case_id
     return payload
 
 
-def _make_doc(distribution_id: str, arrived_at: datetime) -> dict:
+def _make_doc(messageType: str, distribution_id: str, arrived_at: datetime) -> dict:
     """Build a ResourcesInfoCisuWrapper document with the given distributionID."""
-    payload = copy.deepcopy(_SAMPLE_PAYLOAD)
+    payload = copy.deepcopy(_RC_RI_PAYLOAD)
     payload["distributionID"] = distribution_id
     return {
-        "type": "ResourcesInfoCisuWrapper",
+        "type": messageType,
         "arrivedAt": arrived_at,
         "payload": payload,
     }
@@ -70,7 +77,7 @@ class TestGetLastRcRiByCaseId:
             {
                 "type": "ResourcesInfoCisuWrapper",
                 "arrivedAt": arrived_at,
-                "payload": _SAMPLE_PAYLOAD,
+                "payload": _RC_RI_PAYLOAD,
             }
         )
 
@@ -80,7 +87,7 @@ class TestGetLastRcRiByCaseId:
         assert isinstance(result, PersistedMessage)
         assert result.message_type == "ResourcesInfoCisuWrapper"
         assert result.arrived_at == arrived_at
-        assert result.payload == _SAMPLE_PAYLOAD
+        assert result.payload == _RC_RI_PAYLOAD
 
     def test_returns_none_when_not_found(self, real_db):
         """Should return None when no RC-RI document exists for the given caseId."""
@@ -89,7 +96,8 @@ class TestGetLastRcRiByCaseId:
                 "type": "ResourcesInfoCisuWrapper",
                 "arrivedAt": datetime(2024, 8, 1),
                 "payload": _make_payload(
-                    _OTHER_CASE_ID
+                    _OTHER_CASE_ID,
+                    _RC_RI_PAYLOAD,
                 ),  # different caseId in nested path
             }
         )
@@ -104,12 +112,12 @@ class TestGetLastRcRiByCaseId:
                 {
                     "type": "ResourcesInfoCisuWrapper",
                     "arrivedAt": datetime(2024, 1, 1),
-                    "payload": _SAMPLE_PAYLOAD,
+                    "payload": _RC_RI_PAYLOAD,
                 },
                 {
                     "type": "ResourcesInfoCisuWrapper",
                     "arrivedAt": datetime(2024, 8, 1),  # le plus récent
-                    "payload": _SAMPLE_PAYLOAD,
+                    "payload": _RC_RI_PAYLOAD,
                 },
             ]
         )
@@ -124,7 +132,7 @@ class TestGetLastRcRiByCaseId:
             {
                 "type": "SomeOtherWrapper",
                 "arrivedAt": datetime(2024, 8, 1),
-                "payload": _SAMPLE_PAYLOAD,
+                "payload": _RC_RI_PAYLOAD,
             }
         )
 
@@ -150,7 +158,7 @@ class TestGetLastRcRiByCaseId:
 
     def test_returns_none_when_only_matching_document_is_excluded(self, real_db):
         """When the only matching document is excluded, should return None."""
-        real_db["messages"].insert_one(_make_doc(_DIST_ID_A, datetime(2024, 8, 1)))
+        real_db["messages"].insert_one(_make_doc(_RC_RI_TYPE, _DIST_ID_A, datetime(2024, 8, 1)))
 
         result = get_last_rc_ri_by_case_id(_CASE_ID, exclude_distribution_id=_DIST_ID_A)
 
@@ -160,8 +168,8 @@ class TestGetLastRcRiByCaseId:
         """When the most recent document is excluded, should return the previous one."""
         real_db["messages"].insert_many(
             [
-                _make_doc(_DIST_ID_A, datetime(2024, 1, 1)),  # old
-                _make_doc(_DIST_ID_B, datetime(2024, 8, 1)),  # new
+                _make_doc(_RC_RI_TYPE, _DIST_ID_A, datetime(2024, 1, 1)),  # old
+                _make_doc(_RC_RI_TYPE, _DIST_ID_B, datetime(2024, 8, 1)),  # new
             ]
         )
 
@@ -174,8 +182,8 @@ class TestGetLastRcRiByCaseId:
         """Passing exclude_distribution_id=None must not filter anything."""
         real_db["messages"].insert_many(
             [
-                _make_doc(_DIST_ID_A, datetime(2024, 8, 1)),
-                _make_doc(_DIST_ID_B, datetime(2024, 3, 1)),
+                _make_doc(_RC_RI_TYPE, _DIST_ID_A, datetime(2024, 8, 1)),
+                _make_doc(_RC_RI_TYPE, _DIST_ID_B, datetime(2024, 3, 1)),
             ]
         )
 


### PR DESCRIPTION
## 🔎 Détails

Dans le sens 15-18, le converter a besoin d'accéder aux messages RS-RI et RS-SR pour pouvoir reconstruire un RC-RI. Cette PR implémente la couche d'accès aux données.

- [ ] Ajout des méthodes get_last_rs_ri_by_case_id et get_last_rs_sr_by_case_id pour récupérer les derniers messages RS-RI et RS-SR pour un case_id donné
- [ ] la méthode get_last_rs_sr_by_case_id s'appuie sur un pipeline mongo pour récupérer tous les rs_sr correspondant au case_id, les ordonner, les grouper par ressource et ne récupérer que le plus récent
- [ ] Refacto de la méthode _make_doc pour la partager entre les tests des différents types de message
- [ ] Renommage de variables pour oplus de clarté
- [ ] Ajout des TUs relatifs aux méthodes implémentées


## 🔗 Ticket associé

[14. Dans le converter, créer une méthodes pour récupérer la donnée dans le sens 15-18](https://app.asana.com/1/1201445755223134/project/1213308665352873/task/1213430827950672)
