### PR TITLE
Consolidation d'un RC-RI à réception d'un RS-SR

### DIFF
--- a/converter/README.md
+++ b/converter/README.md
@@ -60,6 +60,7 @@ FLASK_APP=converter.converter \
 FLASK_ENV=development \
 FLASK_DEBUG=1 \
 uv run python -m flask run --port 8083
+# in a Linux environment, add --host 0.0.0.0
 ```
 
 *Notes :*

--- a/converter/converter/cisu/resources_info/resources_info_cisu_helper.py
+++ b/converter/converter/cisu/resources_info/resources_info_cisu_helper.py
@@ -1,0 +1,48 @@
+from converter.cisu.resources_info.resources_info_cisu_converter import (
+    ResourcesInfoCISUConverter,
+)
+
+
+def merge_info_and_resources(
+    rs_ri: dict,
+    rs_sr_list: list[dict],
+) -> dict | None:
+    """
+    Enrichit un RS-RI avec les états provenant des RS-SR.
+
+    Retourne :
+        - RC-RI enrichi si toutes les ressources ont un état
+        - None sinon
+    """
+
+    try:
+        resources = rs_ri["content"]["jsonContent"]["embeddedJsonContent"]["message"][
+            "resourcesInfo"
+        ]["resource"]
+    except KeyError:
+        return None
+
+    resource_state_by_id: dict[str, dict] = {}
+
+    for rs_sr in rs_sr_list:
+        try:
+            resource_status = rs_sr["content"]["jsonContent"]["embeddedJsonContent"][
+                "message"
+            ]["resourceStatus"]
+            resource_id = resource_status["resourceId"]
+            resource_state_by_id[resource_id] = resource_status["state"]
+        except KeyError:
+            continue
+
+    # we override each resource.state of RS-RI with state from latest RS-SR, except if missing -> in this case we return nothing
+    for resource in resources:
+        resource_id = resource.get("resourceId")
+
+        if not resource_id or resource_id not in resource_state_by_id:
+            return None
+
+        # state is an array in RS-RI
+        resource["state"] = [resource_state_by_id[resource_id]]
+
+    # transform RS-RI to RC-RI
+    return ResourcesInfoCISUConverter.from_rs_to_cisu(rs_ri)

--- a/converter/converter/cisu/resources_info/resources_info_cisu_helper.py
+++ b/converter/converter/cisu/resources_info/resources_info_cisu_helper.py
@@ -10,32 +10,29 @@ def merge_info_and_resources(
         resources_status_list: liste de resourceStatus (issues des RS-SR déjà extraites)
 
     Returns:
-        - resources enrichies si toutes ont un état
-        - None sinon
+        - resources enrichies si un resource_status a été trouvé ; resource inchangée dans le cas contraire
     """
 
-    resource_state_by_id: dict[str, dict] = {}
+    resource_state_by_resource_id: dict[str, dict] = {}
 
     for resource_status in resources_status_list:
         resource_id = resource_status.get("resourceId")
         state = resource_status.get("state")
 
         if resource_id is not None and state is not None:
-            resource_state_by_id[resource_id] = state
+            resource_state_by_resource_id[resource_id] = state
 
     for resource in resources:
         resource_id = resource.get("resourceId")
         if isinstance(resource_id, str):
-            rs_sr_state = resource_state_by_id.get(resource_id)
+            rs_sr_state = resource_state_by_resource_id.get(resource_id)
         else:
             rs_sr_state = None
 
-        # resource has no state and no RS-SR has been emitted yet
-        if "state" not in resource and rs_sr_state is None:
-            return None
-
         # override or set state from RS-SR
         if rs_sr_state is not None:
-            resource["state"] = [rs_sr_state]
+            resource["state"] = [
+                rs_sr_state
+            ]  # we override the RS-RI state array by a single array with last state only
 
     return resources

--- a/converter/converter/cisu/resources_info/resources_info_cisu_helper.py
+++ b/converter/converter/cisu/resources_info/resources_info_cisu_helper.py
@@ -1,46 +1,41 @@
 def merge_info_and_resources(
-    rs_ri: dict,
-    rs_sr_list: list[dict],
-) -> dict | None:
+    resources: list[dict],
+    resources_status_list: list[dict],
+) -> list[dict] | None:
     """
-    Enrichit un RS-RI avec les états provenant des RS-SR.
+    Enrichit une liste de resources avec les états provenant des resources_status.
 
-    Retourne :
-        - RC-RI enrichi si toutes les ressources ont un état
+    Args:
+        resources: liste de resources (issues du RS-RI déjà extraites)
+        resources_status_list: liste de resourceStatus (issues des RS-SR déjà extraites)
+
+    Returns:
+        - resources enrichies si toutes ont un état
         - None sinon
     """
 
-    try:
-        resources = rs_ri["content"][0]["jsonContent"]["embeddedJsonContent"][
-            "message"
-        ]["resourcesInfo"]["resource"]
-    except KeyError:
-        return None
-
     resource_state_by_id: dict[str, dict] = {}
 
-    for rs_sr in rs_sr_list:
-        try:
-            resource_status = rs_sr["content"][0]["jsonContent"]["embeddedJsonContent"][
-                "message"
-            ]["resourceStatus"]
-            resource_id = resource_status["resourceId"]
-            resource_state_by_id[resource_id] = resource_status["state"]
-        except KeyError:
-            continue
+    for resource_status in resources_status_list:
+        resource_id = resource_status.get("resourceId")
+        state = resource_status.get("state")
 
-    # we override each resource.state of RS-RI with state from latest RS-SR, except if missing -> in this case we return nothing
+        if resource_id is not None and state is not None:
+            resource_state_by_id[resource_id] = state
+
     for resource in resources:
         resource_id = resource.get("resourceId")
-        rs_sr_state = resource_state_by_id.get(resource_id)
+        if isinstance(resource_id, str):
+            rs_sr_state = resource_state_by_id.get(resource_id)
+        else:
+            rs_sr_state = None
 
-        # resource has no state in RS-RI and no RS-SR has been emitted yet
+        # resource has no state and no RS-SR has been emitted yet
         if "state" not in resource and rs_sr_state is None:
             return None
 
-        # a RS-SR has been emitted, we set the RS-RI resource state or override it if present
+        # override or set state from RS-SR
         if rs_sr_state is not None:
             resource["state"] = [rs_sr_state]
 
-    # transform RS-RI to RC-RI
-    return rs_ri
+    return resources

--- a/converter/converter/cisu/resources_info/resources_info_cisu_helper.py
+++ b/converter/converter/cisu/resources_info/resources_info_cisu_helper.py
@@ -1,8 +1,3 @@
-from converter.cisu.resources_info.resources_info_cisu_converter import (
-    ResourcesInfoCISUConverter,
-)
-
-
 def merge_info_and_resources(
     rs_ri: dict,
     rs_sr_list: list[dict],
@@ -16,9 +11,9 @@ def merge_info_and_resources(
     """
 
     try:
-        resources = rs_ri["content"][0]["jsonContent"]["embeddedJsonContent"]["message"][
-            "resourcesInfo"
-        ]["resource"]
+        resources = rs_ri["content"][0]["jsonContent"]["embeddedJsonContent"][
+            "message"
+        ]["resourcesInfo"]["resource"]
     except KeyError:
         return None
 
@@ -48,4 +43,4 @@ def merge_info_and_resources(
             resource["state"] = [rs_sr_state]
 
     # transform RS-RI to RC-RI
-    return ResourcesInfoCISUConverter.from_rs_to_cisu(rs_ri)
+    return rs_ri

--- a/converter/converter/cisu/resources_info/resources_info_cisu_helper.py
+++ b/converter/converter/cisu/resources_info/resources_info_cisu_helper.py
@@ -1,7 +1,7 @@
 def merge_info_and_resources(
     resources: list[dict],
     resources_status_list: list[dict],
-) -> list[dict] | None:
+) -> list[dict]:
     """
     Enrichit une liste de resources avec les états provenant des resources_status.
 

--- a/converter/converter/cisu/resources_info/resources_info_cisu_helper.py
+++ b/converter/converter/cisu/resources_info/resources_info_cisu_helper.py
@@ -16,7 +16,7 @@ def merge_info_and_resources(
     """
 
     try:
-        resources = rs_ri["content"]["jsonContent"]["embeddedJsonContent"]["message"][
+        resources = rs_ri["content"][0]["jsonContent"]["embeddedJsonContent"]["message"][
             "resourcesInfo"
         ]["resource"]
     except KeyError:
@@ -26,7 +26,7 @@ def merge_info_and_resources(
 
     for rs_sr in rs_sr_list:
         try:
-            resource_status = rs_sr["content"]["jsonContent"]["embeddedJsonContent"][
+            resource_status = rs_sr["content"][0]["jsonContent"]["embeddedJsonContent"][
                 "message"
             ]["resourceStatus"]
             resource_id = resource_status["resourceId"]
@@ -37,12 +37,15 @@ def merge_info_and_resources(
     # we override each resource.state of RS-RI with state from latest RS-SR, except if missing -> in this case we return nothing
     for resource in resources:
         resource_id = resource.get("resourceId")
+        rs_sr_state = resource_state_by_id.get(resource_id)
 
-        if not resource_id or resource_id not in resource_state_by_id:
+        # resource has no state in RS-RI and no RS-SR has been emitted yet
+        if "state" not in resource and rs_sr_state is None:
             return None
 
-        # state is an array in RS-RI
-        resource["state"] = [resource_state_by_id[resource_id]]
+        # a RS-SR has been emitted, we set the RS-RI resource state or override it if present
+        if rs_sr_state is not None:
+            resource["state"] = [rs_sr_state]
 
     # transform RS-RI to RC-RI
     return ResourcesInfoCISUConverter.from_rs_to_cisu(rs_ri)

--- a/converter/converter/cisu/resources_status/resources_status_constants.py
+++ b/converter/converter/cisu/resources_status/resources_status_constants.py
@@ -1,0 +1,3 @@
+class ResourcesStatusConstants:
+    RESOURCE_STATUS_PATH = "$.resourceStatus"
+    CASE_ID = "$.caseId"

--- a/converter/converter/cisu/resources_status/resources_status_converter.py
+++ b/converter/converter/cisu/resources_status/resources_status_converter.py
@@ -9,6 +9,12 @@ from converter.cisu.resources_info.resources_info_cisu_helper import (
 from converter.cisu.resources_info.resources_info_cisu_converter import (
     ResourcesInfoCISUConverter,
 )
+from converter.cisu.resources_status.resources_status_constants import (
+    ResourcesStatusConstants,
+)
+from converter.cisu.resources_info.resources_info_cisu_constants import (
+    ResourcesInfoCISUConstants,
+)
 
 from typing import Any, Dict
 
@@ -25,38 +31,35 @@ class ResourcesStatusConverter(BaseCISUConverter):
         return "resourcesInfoCisu"
 
     @classmethod
-    def from_rs_to_cisu(cls, edxl_json: Dict[str, Any]) -> Dict[str, Any]:
+    def from_rs_to_cisu(
+        cls, edxl_json: Dict[str, Any]
+    ) -> Dict[str, Any] | list[Dict[str, Any]]:
         content = cls.copy_rs_input_use_case_content(edxl_json)
-        case_id = get_field_value(content, "$.caseId")
+        case_id = get_field_value(content, ResourcesStatusConstants.CASE_ID)
 
         persisted_rs_ri = get_last_rs_ri_by_case_id(case_id)
-        if persisted_rs_ri is None:  # No RS-RI persisted yet, we return an empty object
-            return {}
+        if persisted_rs_ri is None:  # No RS-RI persisted yet, we return an empty list
+            return []
 
         persisted_rs_sr_list = get_last_rs_sr_per_resource_by_case_id(case_id)
 
         rs_ri = persisted_rs_ri.payload
-        rs_sr = [msg.payload for msg in persisted_rs_sr_list]
+        rs_ri_content = ResourcesInfoCISUConverter.copy_rs_input_use_case_content(rs_ri)
+        rs_sr_content_list = [
+            cls.copy_rs_input_use_case_content(msg.payload)
+            for msg in persisted_rs_sr_list
+        ]
 
         # merge RS-SRs in RS-RI
-        resources = get_field_value(rs_ri, "$.resource")
-        resources_status_list = cls.extract_resource_status_list(rs_sr)
+        resources = get_field_value(
+            rs_ri_content, ResourcesInfoCISUConstants.RESOURCE_PATH
+        )
+        resources_status_list = []
+        for rs_sr in rs_sr_content_list:
+            resources_status_list.append(rs_sr)
 
-        merged_rs_ri = merge_info_and_resources(resources, resources_status_list)
+        merged_resources = merge_info_and_resources(resources, resources_status_list)
 
-        if merged_rs_ri is None:
-            return {}
-
-        set_value(rs_ri, "path", merged_rs_ri)
+        set_value(rs_ri, ResourcesInfoCISUConstants.RESOURCE_PATH, merged_resources)
 
         return ResourcesInfoCISUConverter.from_rs_to_cisu(rs_ri)
-
-    @staticmethod
-    def extract_resource_status_list(rs_sr_list: list[dict]) -> list[dict]:
-        result = []
-
-        for rs_sr in rs_sr_list:
-            resource_status = get_field_value(rs_sr, "$.resourceStatus")
-            result.append(resource_status)
-
-        return result

--- a/converter/converter/cisu/resources_status/resources_status_converter.py
+++ b/converter/converter/cisu/resources_status/resources_status_converter.py
@@ -6,6 +6,9 @@ from converter.repositories.message_repository import (
 from converter.cisu.resources_info.resources_info_cisu_helper import (
     merge_info_and_resources,
 )
+from converter.cisu.resources_info.resources_info_cisu_converter import (
+    ResourcesInfoCISUConverter,
+)
 
 from typing import Any, Dict
 
@@ -38,7 +41,10 @@ class ResourcesStatusConverter(BaseCISUConverter):
         rs_ri_dict = rs_ri.payload
         rs_sr_dicts = [msg.payload for msg in rs_sr_list]
 
-        # build RC-RI from RS-RI & RS-SRs
-        merged_result = merge_info_and_resources(rs_ri_dict, rs_sr_dicts)
+        # merge RS-SRs in RS-RI
+        merged_rs_ri = merge_info_and_resources(rs_ri_dict, rs_sr_dicts)
 
-        return merged_result
+        if merged_rs_ri is None:
+            return None
+
+        return ResourcesInfoCISUConverter.from_rs_to_cisu(merged_rs_ri)

--- a/converter/converter/cisu/resources_status/resources_status_converter.py
+++ b/converter/converter/cisu/resources_status/resources_status_converter.py
@@ -12,6 +12,8 @@ from converter.cisu.resources_info.resources_info_cisu_converter import (
 
 from typing import Any, Dict
 
+from converter.utils import get_field_value, set_value
+
 
 class ResourcesStatusConverter(BaseCISUConverter):
     @classmethod
@@ -23,28 +25,38 @@ class ResourcesStatusConverter(BaseCISUConverter):
         return "resourcesInfoCisu"
 
     @classmethod
-    def from_rs_to_cisu(cls, edxl_json: Dict[str, Any]) -> Dict[str, Any] | None:
-        try:
-            message = edxl_json["content"][0]["jsonContent"]["embeddedJsonContent"][
-                "message"
-            ]
-            case_id = message["resourcesStatus"]["caseId"]
-        except KeyError:
-            raise ValueError("Could not retrieve caseId in RS-SR message")
+    def from_rs_to_cisu(cls, edxl_json: Dict[str, Any]) -> Dict[str, Any]:
+        content = cls.copy_rs_input_use_case_content(edxl_json)
+        case_id = get_field_value(content, "$.caseId")
 
-        rs_ri = get_last_rs_ri_by_case_id(case_id)
-        if rs_ri is None:  # No RS-RI persisted yet, we do nothing
-            return None
+        persisted_rs_ri = get_last_rs_ri_by_case_id(case_id)
+        if persisted_rs_ri is None:  # No RS-RI persisted yet, we return an empty object
+            return {}
 
-        rs_sr_list = get_last_rs_sr_per_resource_by_case_id(case_id)
+        persisted_rs_sr_list = get_last_rs_sr_per_resource_by_case_id(case_id)
 
-        rs_ri_dict = rs_ri.payload
-        rs_sr_dicts = [msg.payload for msg in rs_sr_list]
+        rs_ri = persisted_rs_ri.payload
+        rs_sr = [msg.payload for msg in persisted_rs_sr_list]
 
         # merge RS-SRs in RS-RI
-        merged_rs_ri = merge_info_and_resources(rs_ri_dict, rs_sr_dicts)
+        resources = get_field_value(rs_ri, "$.resource")
+        resources_status_list = cls.extract_resource_status_list(rs_sr)
+
+        merged_rs_ri = merge_info_and_resources(resources, resources_status_list)
 
         if merged_rs_ri is None:
-            return None
+            return {}
 
-        return ResourcesInfoCISUConverter.from_rs_to_cisu(merged_rs_ri)
+        set_value(rs_ri, "path", merged_rs_ri)
+
+        return ResourcesInfoCISUConverter.from_rs_to_cisu(rs_ri)
+
+    @staticmethod
+    def extract_resource_status_list(rs_sr_list: list[dict]) -> list[dict]:
+        result = []
+
+        for rs_sr in rs_sr_list:
+            resource_status = get_field_value(rs_sr, "$.resourceStatus")
+            result.append(resource_status)
+
+        return result

--- a/converter/converter/cisu/resources_status/resources_status_converter.py
+++ b/converter/converter/cisu/resources_status/resources_status_converter.py
@@ -7,7 +7,7 @@ from converter.cisu.resources_info.resources_info_cisu_helper import (
     merge_info_and_resources,
 )
 
-from typing import Any, Dict, List
+from typing import Any, Dict
 
 
 class ResourcesStatusConverter(BaseCISUConverter):

--- a/converter/converter/cisu/resources_status/resources_status_converter.py
+++ b/converter/converter/cisu/resources_status/resources_status_converter.py
@@ -1,4 +1,13 @@
 from converter.cisu.base_cisu_converter import BaseCISUConverter
+from converter.repositories.message_repository import (
+    get_last_rs_ri_by_case_id,
+    get_last_rs_sr_per_resource_by_case_id,
+)
+from converter.cisu.resources_info.resources_info_cisu_helper import (
+    merge_info_and_resources,
+)
+
+from typing import Any, Dict, List
 
 
 class ResourcesStatusConverter(BaseCISUConverter):
@@ -9,3 +18,27 @@ class ResourcesStatusConverter(BaseCISUConverter):
     @classmethod
     def get_cisu_message_type(cls) -> str:
         return "resourcesInfoCisu"
+
+    @classmethod
+    def from_rs_to_cisu(cls, edxl_json: Dict[str, Any]) -> Dict[str, Any] | None:
+        try:
+            message = edxl_json["content"][0]["jsonContent"]["embeddedJsonContent"][
+                "message"
+            ]
+            case_id = message["resourcesStatus"]["caseId"]
+        except KeyError:
+            raise ValueError("Could not retrieve caseId in RS-SR message")
+
+        rs_ri = get_last_rs_ri_by_case_id(case_id)
+        if rs_ri is None:  # No RS-RI persisted yet, we do nothing
+            return None
+
+        rs_sr_list = get_last_rs_sr_per_resource_by_case_id(case_id)
+
+        rs_ri_dict = rs_ri.payload
+        rs_sr_dicts = [msg.payload for msg in rs_sr_list]
+
+        # build RC-RI from RS-RI & RS-SRs
+        merged_result = merge_info_and_resources(rs_ri_dict, rs_sr_dicts)
+
+        return merged_result

--- a/converter/converter/cisu/resources_status/resources_status_converter.py
+++ b/converter/converter/cisu/resources_status/resources_status_converter.py
@@ -54,11 +54,8 @@ class ResourcesStatusConverter(BaseCISUConverter):
         resources = get_field_value(
             rs_ri_content, ResourcesInfoCISUConstants.RESOURCE_PATH
         )
-        resources_status_list = []
-        for rs_sr in rs_sr_content_list:
-            resources_status_list.append(rs_sr)
 
-        merged_resources = merge_info_and_resources(resources, resources_status_list)
+        merged_resources = merge_info_and_resources(resources, rs_sr_content_list)
 
         set_value(rs_ri, ResourcesInfoCISUConstants.RESOURCE_PATH, merged_resources)
 

--- a/converter/tests/cisu/test_resources_info_cisu_helper.py
+++ b/converter/tests/cisu/test_resources_info_cisu_helper.py
@@ -7,30 +7,34 @@ from converter.cisu.resources_info.resources_info_cisu_helper import (
 
 def build_rs_ri(resources):
     return {
-        "content": [{
-            "jsonContent": {
-                "embeddedJsonContent": {
-                    "message": {"resourcesInfo": {"resource": resources}}
+        "content": [
+            {
+                "jsonContent": {
+                    "embeddedJsonContent": {
+                        "message": {"resourcesInfo": {"resource": resources}}
+                    }
                 }
             }
-        }]
+        ]
     }
 
 
 def build_rs_sr(resource_id, state):
     return {
-        "content": [{
-            "jsonContent": {
-                "embeddedJsonContent": {
-                    "message": {
-                        "resourceStatus": {
-                            "resourceId": resource_id,
-                            "state": state,
+        "content": [
+            {
+                "jsonContent": {
+                    "embeddedJsonContent": {
+                        "message": {
+                            "resourceStatus": {
+                                "resourceId": resource_id,
+                                "state": state,
+                            }
                         }
                     }
                 }
             }
-        }]
+        ]
     }
 
 

--- a/converter/tests/cisu/test_resources_info_cisu_helper.py
+++ b/converter/tests/cisu/test_resources_info_cisu_helper.py
@@ -5,39 +5,6 @@ from converter.cisu.resources_info.resources_info_cisu_helper import (
 )
 
 
-def build_rs_ri(resources):
-    return {
-        "content": [
-            {
-                "jsonContent": {
-                    "embeddedJsonContent": {
-                        "message": {"resourcesInfo": {"resource": resources}}
-                    }
-                }
-            }
-        ]
-    }
-
-
-def build_rs_sr(resource_id, state):
-    return {
-        "content": [
-            {
-                "jsonContent": {
-                    "embeddedJsonContent": {
-                        "message": {
-                            "resourceStatus": {
-                                "resourceId": resource_id,
-                                "state": state,
-                            }
-                        }
-                    }
-                }
-            }
-        ]
-    }
-
-
 @pytest.fixture(autouse=True)
 def mock_converter(monkeypatch):
     monkeypatch.setattr(
@@ -47,107 +14,80 @@ def mock_converter(monkeypatch):
 
 
 def test_merge_success():
-    rs_ri = build_rs_ri(
-        [
-            {"resourceId": "r1"},
-            {"resourceId": "r2"},
-        ]
-    )
-
-    rs_sr_list = [
-        build_rs_sr("r1", {"status": "OK"}),
-        build_rs_sr("r2", {"status": "KO"}),
+    resources = [
+        {"resourceId": "r1"},
+        {"resourceId": "r2"},
     ]
 
-    result = merge_info_and_resources(rs_ri, rs_sr_list)
+    rs_status_list = [
+        {"resourceId": "r1", "state": {"status": "OK"}},
+        {"resourceId": "r2", "state": {"status": "KO"}},
+    ]
+
+    result = merge_info_and_resources(resources, rs_status_list)
 
     assert result is not None
-
-    resources = result["content"][0]["jsonContent"]["embeddedJsonContent"]["message"][
-        "resourcesInfo"
-    ]["resource"]
 
     assert resources[0]["state"] == [{"status": "OK"}]
     assert resources[1]["state"] == [{"status": "KO"}]
 
 
-def test_missing_resources_info():
-    rs_ri = {}
-    rs_sr_list = []
-
-    result = merge_info_and_resources(rs_ri, rs_sr_list)
-
-    assert result is None
-
-
 def test_missing_state_for_resource():
-    rs_ri = build_rs_ri(
-        [
-            {"resourceId": "r1"},
-            {"resourceId": "r2"},
-        ]
-    )
+    resources = [
+        {"resourceId": "r1"},
+        {"resourceId": "r2"},
+    ]
 
-    rs_sr_list = [
-        build_rs_sr("r1", {"status": "OK"}),
+    resources_status_list = [
+        {"resourceId": "r1", "state": {"status": "OK"}},
         # r2 manquant
     ]
 
-    result = merge_info_and_resources(rs_ri, rs_sr_list)
+    result = merge_info_and_resources(resources, resources_status_list)
 
     assert result is None
 
 
 def test_missing_resource_id():
-    rs_ri = build_rs_ri(
-        [
-            {"resourceId": "r1"},
-            {},  # pas de resourceId
-        ]
-    )
-
-    rs_sr_list = [
-        build_rs_sr("r1", {"status": "OK"}),
+    resources = [
+        {"resourceId": "r1"},
+        {},  # pas de resourceId
     ]
 
-    result = merge_info_and_resources(rs_ri, rs_sr_list)
+    resources_status_list = [
+        {"resourceId": "r1", "state": {"status": "OK"}},
+    ]
+
+    result = merge_info_and_resources(resources, resources_status_list)
 
     assert result is None
 
 
-def test_invalid_rs_sr_ignored():
-    rs_ri = build_rs_ri(
-        [
-            {"resourceId": "r1"},
-        ]
-    )
-
-    rs_sr_list = [
-        {},  # invalide
-        build_rs_sr("r1", {"status": "OK"}),
+def test_invalid_rs_status_ignored():
+    resources = [
+        {"resourceId": "r1"},
     ]
 
-    result = merge_info_and_resources(rs_ri, rs_sr_list)
+    resources_status_list = [
+        {},  # invalide
+        {"resourceId": "r1", "state": {"status": "OK"}},
+    ]
+
+    result = merge_info_and_resources(resources, resources_status_list)
 
     assert result is not None
 
 
 def test_duplicate_resource_id_last_wins():
-    rs_ri = build_rs_ri(
-        [
-            {"resourceId": "r1"},
-        ]
-    )
-
-    rs_sr_list = [
-        build_rs_sr("r1", {"status": "OLD"}),
-        build_rs_sr("r1", {"status": "NEW"}),
+    resources = [
+        {"resourceId": "r1"},
     ]
 
-    result = merge_info_and_resources(rs_ri, rs_sr_list)
+    resources_status_list = [
+        {"resourceId": "r1", "state": {"status": "OLD"}},
+        {"resourceId": "r1", "state": {"status": "NEW"}},
+    ]
 
-    resources = result["content"][0]["jsonContent"]["embeddedJsonContent"]["message"][
-        "resourcesInfo"
-    ]["resource"]
+    result = merge_info_and_resources(resources, resources_status_list)
 
     assert resources[0]["state"] == [{"status": "NEW"}]

--- a/converter/tests/cisu/test_resources_info_cisu_helper.py
+++ b/converter/tests/cisu/test_resources_info_cisu_helper.py
@@ -43,9 +43,14 @@ def test_missing_state_for_resource():
         # r2 manquant
     ]
 
+    expected_result = [
+        {"resourceId": "r1", "state": [{"status": "OK"}]},
+        {"resourceId": "r2"},
+    ]
+
     result = merge_info_and_resources(resources, resources_status_list)
 
-    assert result is None
+    assert result == expected_result
 
 
 def test_missing_resource_id():
@@ -57,10 +62,10 @@ def test_missing_resource_id():
     resources_status_list = [
         {"resourceId": "r1", "state": {"status": "OK"}},
     ]
-
+    expected_result = [{"resourceId": "r1", "state": [{"status": "OK"}]}, {}]
     result = merge_info_and_resources(resources, resources_status_list)
 
-    assert result is None
+    assert result == expected_result
 
 
 def test_invalid_rs_status_ignored():

--- a/converter/tests/cisu/test_resources_info_cisu_helper.py
+++ b/converter/tests/cisu/test_resources_info_cisu_helper.py
@@ -7,19 +7,19 @@ from converter.cisu.resources_info.resources_info_cisu_helper import (
 
 def build_rs_ri(resources):
     return {
-        "content": {
+        "content": [{
             "jsonContent": {
                 "embeddedJsonContent": {
                     "message": {"resourcesInfo": {"resource": resources}}
                 }
             }
-        }
+        }]
     }
 
 
 def build_rs_sr(resource_id, state):
     return {
-        "content": {
+        "content": [{
             "jsonContent": {
                 "embeddedJsonContent": {
                     "message": {
@@ -30,7 +30,7 @@ def build_rs_sr(resource_id, state):
                     }
                 }
             }
-        }
+        }]
     }
 
 
@@ -59,7 +59,7 @@ def test_merge_success():
 
     assert result is not None
 
-    resources = result["content"]["jsonContent"]["embeddedJsonContent"]["message"][
+    resources = result["content"][0]["jsonContent"]["embeddedJsonContent"]["message"][
         "resourcesInfo"
     ]["resource"]
 
@@ -142,7 +142,7 @@ def test_duplicate_resource_id_last_wins():
 
     result = merge_info_and_resources(rs_ri, rs_sr_list)
 
-    resources = result["content"]["jsonContent"]["embeddedJsonContent"]["message"][
+    resources = result["content"][0]["jsonContent"]["embeddedJsonContent"]["message"][
         "resourcesInfo"
     ]["resource"]
 

--- a/converter/tests/cisu/test_resources_info_cisu_helper.py
+++ b/converter/tests/cisu/test_resources_info_cisu_helper.py
@@ -1,0 +1,149 @@
+import pytest
+
+from converter.cisu.resources_info.resources_info_cisu_helper import (
+    merge_info_and_resources,
+)
+
+
+def build_rs_ri(resources):
+    return {
+        "content": {
+            "jsonContent": {
+                "embeddedJsonContent": {
+                    "message": {"resourcesInfo": {"resource": resources}}
+                }
+            }
+        }
+    }
+
+
+def build_rs_sr(resource_id, state):
+    return {
+        "content": {
+            "jsonContent": {
+                "embeddedJsonContent": {
+                    "message": {
+                        "resourceStatus": {
+                            "resourceId": resource_id,
+                            "state": state,
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+
+@pytest.fixture(autouse=True)
+def mock_converter(monkeypatch):
+    monkeypatch.setattr(
+        "converter.cisu.resources_info.resources_info_cisu_converter.ResourcesInfoCISUConverter.from_rs_to_cisu",
+        lambda x: x,
+    )
+
+
+def test_merge_success():
+    rs_ri = build_rs_ri(
+        [
+            {"resourceId": "r1"},
+            {"resourceId": "r2"},
+        ]
+    )
+
+    rs_sr_list = [
+        build_rs_sr("r1", {"status": "OK"}),
+        build_rs_sr("r2", {"status": "KO"}),
+    ]
+
+    result = merge_info_and_resources(rs_ri, rs_sr_list)
+
+    assert result is not None
+
+    resources = result["content"]["jsonContent"]["embeddedJsonContent"]["message"][
+        "resourcesInfo"
+    ]["resource"]
+
+    assert resources[0]["state"] == [{"status": "OK"}]
+    assert resources[1]["state"] == [{"status": "KO"}]
+
+
+def test_missing_resources_info():
+    rs_ri = {}
+    rs_sr_list = []
+
+    result = merge_info_and_resources(rs_ri, rs_sr_list)
+
+    assert result is None
+
+
+def test_missing_state_for_resource():
+    rs_ri = build_rs_ri(
+        [
+            {"resourceId": "r1"},
+            {"resourceId": "r2"},
+        ]
+    )
+
+    rs_sr_list = [
+        build_rs_sr("r1", {"status": "OK"}),
+        # r2 manquant
+    ]
+
+    result = merge_info_and_resources(rs_ri, rs_sr_list)
+
+    assert result is None
+
+
+def test_missing_resource_id():
+    rs_ri = build_rs_ri(
+        [
+            {"resourceId": "r1"},
+            {},  # pas de resourceId
+        ]
+    )
+
+    rs_sr_list = [
+        build_rs_sr("r1", {"status": "OK"}),
+    ]
+
+    result = merge_info_and_resources(rs_ri, rs_sr_list)
+
+    assert result is None
+
+
+def test_invalid_rs_sr_ignored():
+    rs_ri = build_rs_ri(
+        [
+            {"resourceId": "r1"},
+        ]
+    )
+
+    rs_sr_list = [
+        {},  # invalide
+        build_rs_sr("r1", {"status": "OK"}),
+    ]
+
+    result = merge_info_and_resources(rs_ri, rs_sr_list)
+
+    assert result is not None
+
+
+def test_duplicate_resource_id_last_wins():
+    rs_ri = build_rs_ri(
+        [
+            {"resourceId": "r1"},
+        ]
+    )
+
+    rs_sr_list = [
+        build_rs_sr("r1", {"status": "OLD"}),
+        build_rs_sr("r1", {"status": "NEW"}),
+    ]
+
+    result = merge_info_and_resources(rs_ri, rs_sr_list)
+
+    resources = result["content"]["jsonContent"]["embeddedJsonContent"]["message"][
+        "resourcesInfo"
+    ]["resource"]
+
+    assert resources[0]["state"] == [{"status": "NEW"}]

--- a/converter/tests/cisu/test_resources_info_cisu_helper.py
+++ b/converter/tests/cisu/test_resources_info_cisu_helper.py
@@ -88,6 +88,6 @@ def test_duplicate_resource_id_last_wins():
         {"resourceId": "r1", "state": {"status": "NEW"}},
     ]
 
-    result = merge_info_and_resources(resources, resources_status_list)
+    resources = merge_info_and_resources(resources, resources_status_list)
 
     assert resources[0]["state"] == [{"status": "NEW"}]

--- a/converter/tests/cisu/test_resources_status_converter.py
+++ b/converter/tests/cisu/test_resources_status_converter.py
@@ -1,0 +1,79 @@
+import pytest
+from unittest.mock import patch, MagicMock
+
+from converter.cisu.resources_status.resources_status_converter import (
+    ResourcesStatusConverter,
+)
+
+
+def build_valid_edxl(case_id="CASE123"):
+    # we just need the mandatory path here
+    return {
+        "content": [
+            {
+                "jsonContent": {
+                    "embeddedJsonContent": {
+                        "message": {"resourcesStatus": {"caseId": case_id}}
+                    }
+                }
+            }
+        ]
+    }
+
+
+def test_from_rs_to_cisu_happy_path():
+    edxl_json = build_valid_edxl()
+
+    mock_rs_ri = MagicMock()
+    mock_rs_ri.payload = {
+        "ri": "data"
+    }  # irrelevant content : we just test the orchestration here
+
+    mock_rs_sr_1 = MagicMock()
+    mock_rs_sr_1.payload = {"sr": "data1"}
+
+    mock_rs_sr_2 = MagicMock()
+    mock_rs_sr_2.payload = {"sr": "data2"}
+
+    expected_result = [{"merged": "ok"}]
+
+    with (
+        patch(
+            "converter.cisu.resources_status.resources_status_converter.get_last_rs_ri_by_case_id",
+            return_value=mock_rs_ri,
+        ) as mock_get_ri,
+        patch(
+            "converter.cisu.resources_status.resources_status_converter.get_last_rs_sr_per_resource_by_case_id",
+            return_value=[mock_rs_sr_1, mock_rs_sr_2],
+        ) as mock_get_sr,
+        patch(
+            "converter.cisu.resources_status.resources_status_converter.merge_info_and_resources",
+            return_value=expected_result,
+        ) as mock_merge,
+    ):
+        result = ResourcesStatusConverter.from_rs_to_cisu(edxl_json)
+        assert result == expected_result
+
+        mock_get_ri.assert_called_once_with("CASE123")
+        mock_get_sr.assert_called_once_with("CASE123")
+        mock_merge.assert_called_once_with(
+            {"ri": "data"}, [{"sr": "data1"}, {"sr": "data2"}]
+        )
+
+
+def test_from_rs_to_cisu_missing_case_id():
+    edxl_json = {}
+
+    with pytest.raises(ValueError, match="Could not retrieve caseId"):
+        ResourcesStatusConverter.from_rs_to_cisu(edxl_json)
+
+
+def test_from_rs_to_cisu_no_rs_ri():
+    edxl_json = build_valid_edxl()
+
+    with patch(
+        "converter.cisu.resources_status.resources_status_converter.get_last_rs_ri_by_case_id",
+        return_value=None,
+    ):
+        result = ResourcesStatusConverter.from_rs_to_cisu(edxl_json)
+        assert result is None

--- a/converter/tests/cisu/test_resources_status_converter.py
+++ b/converter/tests/cisu/test_resources_status_converter.py
@@ -3,6 +3,9 @@ from unittest.mock import patch, MagicMock
 from converter.cisu.resources_status.resources_status_converter import (
     ResourcesStatusConverter,
 )
+from converter.cisu.resources_info.resources_info_cisu_constants import (
+    ResourcesInfoCISUConstants,
+)
 
 
 def build_valid_edxl(case_id="CASE123"):
@@ -56,9 +59,8 @@ def test_from_rs_to_cisu_happy_path():
             side_effect=mock_get_field_value,
         ) as mock_get_field,
         patch(
-            "converter.cisu.resources_status.resources_status_converter.ResourcesStatusConverter.extract_resource_status_list",
-            return_value=[{"sr": "data1"}, {"sr": "data2"}],
-        ) as mock_extract_status,
+            "converter.cisu.resources_status.resources_status_converter.set_value"
+        ) as mock_set_value,
         patch(
             "converter.cisu.resources_status.resources_status_converter.merge_info_and_resources",
             return_value=merged_rs_ri,
@@ -67,6 +69,14 @@ def test_from_rs_to_cisu_happy_path():
             "converter.cisu.resources_status.resources_status_converter.ResourcesInfoCISUConverter.from_rs_to_cisu",
             return_value=expected_result,
         ) as mock_convert,
+        patch(
+            "converter.cisu.resources_status.resources_status_converter.ResourcesStatusConverter.copy_rs_input_use_case_content",
+            side_effect=lambda x: x,
+        ),
+        patch(
+            "converter.cisu.resources_status.resources_status_converter.ResourcesInfoCISUConverter.copy_rs_input_use_case_content",
+            side_effect=lambda x: x,
+        ),
     ):
         result = ResourcesStatusConverter.from_rs_to_cisu(edxl_json)
 
@@ -76,15 +86,18 @@ def test_from_rs_to_cisu_happy_path():
         mock_get_sr.assert_called_once_with("CASE123")
 
         mock_get_field.assert_any_call(mock_rs_ri.payload, "$.resource")
-        mock_extract_status.assert_called_once_with([{"sr": "data1"}, {"sr": "data2"}])
 
         mock_merge.assert_called_once_with(
             {"ri": "data"}, [{"sr": "data1"}, {"sr": "data2"}]
         )
 
-        mock_convert.assert_called_once_with(
-            {"ri": "data", "path": {"merged": "rs_ri"}}
+        mock_set_value.assert_called_once_with(
+            mock_rs_ri.payload,
+            ResourcesInfoCISUConstants.RESOURCE_PATH,
+            merged_rs_ri,
         )
+
+        mock_convert.assert_called_once_with(mock_rs_ri.payload)
 
 
 def test_from_rs_to_cisu_no_rs_ri():
@@ -95,4 +108,4 @@ def test_from_rs_to_cisu_no_rs_ri():
         return_value=None,
     ):
         result = ResourcesStatusConverter.from_rs_to_cisu(edxl_json)
-        assert result == {}
+        assert result == []

--- a/converter/tests/cisu/test_resources_status_converter.py
+++ b/converter/tests/cisu/test_resources_status_converter.py
@@ -1,4 +1,3 @@
-import pytest
 from unittest.mock import patch, MagicMock
 
 from converter.cisu.resources_status.resources_status_converter import (

--- a/converter/tests/cisu/test_resources_status_converter.py
+++ b/converter/tests/cisu/test_resources_status_converter.py
@@ -35,7 +35,8 @@ def test_from_rs_to_cisu_happy_path():
     mock_rs_sr_2 = MagicMock()
     mock_rs_sr_2.payload = {"sr": "data2"}
 
-    expected_result = [{"merged": "ok"}]
+    merged_rs_ri = {"merged: rs_ri"}
+    expected_result = {"final": "rc_ri"}
 
     with (
         patch(
@@ -48,8 +49,12 @@ def test_from_rs_to_cisu_happy_path():
         ) as mock_get_sr,
         patch(
             "converter.cisu.resources_status.resources_status_converter.merge_info_and_resources",
-            return_value=expected_result,
+            return_value=merged_rs_ri,
         ) as mock_merge,
+        patch(
+            "converter.cisu.resources_status.resources_status_converter.ResourcesInfoCISUConverter.from_rs_to_cisu",
+            return_value=expected_result,
+        ) as mock_convert,
     ):
         result = ResourcesStatusConverter.from_rs_to_cisu(edxl_json)
         assert result == expected_result
@@ -59,6 +64,7 @@ def test_from_rs_to_cisu_happy_path():
         mock_merge.assert_called_once_with(
             {"ri": "data"}, [{"sr": "data1"}, {"sr": "data2"}]
         )
+        mock_convert.assert_called_once_with(merged_rs_ri)
 
 
 def test_from_rs_to_cisu_missing_case_id():

--- a/converter/tests/cisu/test_resources_status_converter.py
+++ b/converter/tests/cisu/test_resources_status_converter.py
@@ -25,9 +25,7 @@ def test_from_rs_to_cisu_happy_path():
     edxl_json = build_valid_edxl()
 
     mock_rs_ri = MagicMock()
-    mock_rs_ri.payload = {
-        "ri": "data"
-    }  # irrelevant content : we just test the orchestration here
+    mock_rs_ri.payload = {"ri": "data"}
 
     mock_rs_sr_1 = MagicMock()
     mock_rs_sr_1.payload = {"sr": "data1"}
@@ -35,8 +33,15 @@ def test_from_rs_to_cisu_happy_path():
     mock_rs_sr_2 = MagicMock()
     mock_rs_sr_2.payload = {"sr": "data2"}
 
-    merged_rs_ri = {"merged: rs_ri"}
+    merged_rs_ri = {"merged": "rs_ri"}
     expected_result = {"final": "rc_ri"}
+
+    def mock_get_field_value(input_data, path):
+        if path == "$.caseId":
+            return "CASE123"
+        if path == "$.resource":
+            return {"ri": "data"}
+        return None
 
     with (
         patch(
@@ -48,6 +53,14 @@ def test_from_rs_to_cisu_happy_path():
             return_value=[mock_rs_sr_1, mock_rs_sr_2],
         ) as mock_get_sr,
         patch(
+            "converter.cisu.resources_status.resources_status_converter.get_field_value",
+            side_effect=mock_get_field_value,
+        ) as mock_get_field,
+        patch(
+            "converter.cisu.resources_status.resources_status_converter.ResourcesStatusConverter.extract_resource_status_list",
+            return_value=[{"sr": "data1"}, {"sr": "data2"}],
+        ) as mock_extract_status,
+        patch(
             "converter.cisu.resources_status.resources_status_converter.merge_info_and_resources",
             return_value=merged_rs_ri,
         ) as mock_merge,
@@ -57,21 +70,22 @@ def test_from_rs_to_cisu_happy_path():
         ) as mock_convert,
     ):
         result = ResourcesStatusConverter.from_rs_to_cisu(edxl_json)
+
         assert result == expected_result
 
         mock_get_ri.assert_called_once_with("CASE123")
         mock_get_sr.assert_called_once_with("CASE123")
+
+        mock_get_field.assert_any_call(mock_rs_ri.payload, "$.resource")
+        mock_extract_status.assert_called_once_with([{"sr": "data1"}, {"sr": "data2"}])
+
         mock_merge.assert_called_once_with(
             {"ri": "data"}, [{"sr": "data1"}, {"sr": "data2"}]
         )
-        mock_convert.assert_called_once_with(merged_rs_ri)
 
-
-def test_from_rs_to_cisu_missing_case_id():
-    edxl_json = {}
-
-    with pytest.raises(ValueError, match="Could not retrieve caseId"):
-        ResourcesStatusConverter.from_rs_to_cisu(edxl_json)
+        mock_convert.assert_called_once_with(
+            {"ri": "data", "path": {"merged": "rs_ri"}}
+        )
 
 
 def test_from_rs_to_cisu_no_rs_ri():
@@ -82,4 +96,4 @@ def test_from_rs_to_cisu_no_rs_ri():
         return_value=None,
     ):
         result = ResourcesStatusConverter.from_rs_to_cisu(edxl_json)
-        assert result is None
+        assert result == {}


### PR DESCRIPTION
## 🔎 Détails

Dans le converter, à la réception d’un RS-SR, si toutes les ressources ont un statut, créer le message RC-RI et le retourner pour transmission aux pompiers.

- [ ] Ajout d'un helper mergeInfoAndResources, qui génère un RC-RI à partir d'un RS-RI et d'une liste de RS-SR
- [ ] Règle de gestion : RC-RI si et seulement si toutes les ressources référencées dans le RS-RI ont un RS-SR associé dans la liste, None sinon
- [ ] Ajout de tests sur cett méthode


## 📄 Documentation

> Ajoutez un (des) lien(s) vers la documentation si nécessaire

## 📸 Captures d'écran

| Avant | Après |
| ----- | ----- |
|       |       |

## 🔗 Ticket associé

[Asana](https://app.asana.com/1/1201445755223134/project/1213507902085164/task/1213430827950673)
