### PR TITLE
Feat/converter : Ne pas envoyer d'erreur si aucune ressource CISU-compatible après filtrage

### DIFF
--- a/converter/converter/cisu/resources_info/resources_info_cisu_converter.py
+++ b/converter/converter/cisu/resources_info/resources_info_cisu_converter.py
@@ -201,7 +201,7 @@ class ResourcesInfoCISUConverter(BaseCISUConverter):
         return messages
 
     @classmethod
-    def from_rs_to_cisu(cls, edxl_json: Dict[str, Any]) -> Dict[str, Any]:
+    def from_rs_to_cisu(cls, edxl_json: Dict[str, Any]) -> Dict[str, Any] | list[Dict[str, Any]]:
         logger.info("Converting from RS to CISU format for Resources Info message.")
         logger.debug(f"Message content: {edxl_json}")
         output_json = cls.copy_rs_input_content(edxl_json)
@@ -214,10 +214,8 @@ class ResourcesInfoCISUConverter(BaseCISUConverter):
         converted_resources = cls.convert_resources_to_cisu(resources)
 
         if len(converted_resources) < 1:
-            raise ValueError(
-                "Could not map resources to CISU. "
-                "At least one resource must have a CISU compatible vehicleType. "
-            )
+            logger.info("No CISU-compatible resources remain after filtering — returning empty list.")
+            return []
 
         set_value(
             output_use_case_json,

--- a/converter/converter/cisu/resources_info/resources_info_cisu_converter.py
+++ b/converter/converter/cisu/resources_info/resources_info_cisu_converter.py
@@ -201,7 +201,9 @@ class ResourcesInfoCISUConverter(BaseCISUConverter):
         return messages
 
     @classmethod
-    def from_rs_to_cisu(cls, edxl_json: Dict[str, Any]) -> Dict[str, Any] | list[Dict[str, Any]]:
+    def from_rs_to_cisu(
+        cls, edxl_json: Dict[str, Any]
+    ) -> Dict[str, Any] | list[Dict[str, Any]]:
         logger.info("Converting from RS to CISU format for Resources Info message.")
         logger.debug(f"Message content: {edxl_json}")
         output_json = cls.copy_rs_input_content(edxl_json)
@@ -214,7 +216,9 @@ class ResourcesInfoCISUConverter(BaseCISUConverter):
         converted_resources = cls.convert_resources_to_cisu(resources)
 
         if len(converted_resources) < 1:
-            logger.info("No CISU-compatible resources remain after filtering — returning empty list.")
+            logger.info(
+                "No CISU-compatible resources remain after filtering — returning empty list."
+            )
             return []
 
         set_value(

--- a/converter/tests/cisu/test_resources_info_converter.py
+++ b/converter/tests/cisu/test_resources_info_converter.py
@@ -32,19 +32,14 @@ all_file_names = [f["name"] for f in all_usecase_files]
 
 # Dictionnaire des cas d'erreur : file_name -> message attendu
 ERROR_CASES = {
-    **{
-        name: "No states found in resource, mandatory for CISU conversion."
-        for name in usecase_files_with_empty_state
-    },
-    **{
-        name: "At least one resource must have a CISU compatible vehicleType."
-        for name in usecase_files_with_unsupported_vehicle_type
-    },
+    name: "No states found in resource, mandatory for CISU conversion."
+    for name in usecase_files_with_empty_state
 }
 
 TEST_CASES = [
     (name, ValueError, ERROR_CASES[name]) if name in ERROR_CASES else (name, None, None)
     for name in all_file_names
+    if name not in usecase_files_with_unsupported_vehicle_type
 ]
 
 
@@ -83,6 +78,21 @@ def test_rs_to_cisu(file_name, expected_exception, expected_message):
         # Cas d'erreur attendu
         with pytest.raises(expected_exception, match=expected_message):
             ResourcesInfoCISUConverter.from_rs_to_cisu(edxl_json)
+
+
+@pytest.mark.parametrize(
+    "file_name",
+    usecase_files_with_unsupported_vehicle_type,
+)
+def test_rs_to_cisu_returns_empty_list_when_no_cisu_compatible_resource(file_name):
+    """Quand toutes les ressources ont un vehicleType non supporté, from_rs_to_cisu
+    doit retourner [] au lieu de lever une erreur."""
+    usecase_file = next(f for f in all_usecase_files if f["name"] == file_name)
+    edxl_json = TestHelper.create_edxl_json_from_sample(
+        TestConstants.EDXL_HEALTH_TO_FIRE_ENVELOPE_PATH, usecase_file["path"]
+    )
+    result = ResourcesInfoCISUConverter.from_rs_to_cisu(edxl_json)
+    assert result == []
 
 
 def test_rs_to_cisu_should_delete_patient_id():


### PR DESCRIPTION
## 🔎 Détails

Lors de la conversion d'un RS-RI en RC-RI, si toutes les ressources sont filtrées (ex : vehicleType non supporté comme TSU.AMB), le converter levait une `ValueError` qui remontait comme une erreur au dispatcher.

Cette PR change le comportement du converter lorsqu'il ne reste aucune ressource après filtrage, aucun message ne doit être transmis et pas de levé d'erreur.

Changements :
- Retourner un tableau vide au lieu de raise ValueError quand converted_resources est vide après filtrage des vehicleTypes.
- Tests mis à jour : le cas vehicleType non supporté n'est plus un cas d'erreur attendu. Un test dédié vérifie le retour [].

## 📄 Documentation

> Ajoutez un (des) lien(s) vers la documentation si nécessaire

## 📸 Captures d'écran

| Avant | Après |
| ----- | ----- |
|       |       |

## 🔗 Ticket associé

[Ne pas envoyer d'erreur si après filtrage des ressources, il n'y a plus aucune ressource à envoyer](https://app.asana.com/1/1201445755223134/project/1213699865754209/task/1213821811433962?focus=true)
