### PR TITLE
Feat(converter) : lever une erreur explicite sur RS-SR si aucun RS-RI n’est trouvé pour le caseId

### DIFF
--- a/converter/converter/cisu/resources_status/resources_status_converter.py
+++ b/converter/converter/cisu/resources_status/resources_status_converter.py
@@ -38,8 +38,8 @@ class ResourcesStatusConverter(BaseCISUConverter):
         case_id = get_field_value(content, ResourcesStatusConstants.CASE_ID)
 
         persisted_rs_ri = get_last_rs_ri_by_case_id(case_id)
-        if persisted_rs_ri is None:  # No RS-RI persisted yet, we return an empty list
-            return []
+        if persisted_rs_ri is None:
+            raise ValueError(f"No RS-RI found for caseId: {case_id!r}")
 
         persisted_rs_sr_list = get_last_rs_sr_per_resource_by_case_id(case_id)
 

--- a/converter/tests/cisu/test_resources_status_converter.py
+++ b/converter/tests/cisu/test_resources_status_converter.py
@@ -1,5 +1,6 @@
 import copy
 import json
+import pytest
 from pathlib import Path
 from unittest.mock import patch
 
@@ -107,5 +108,5 @@ def test_from_rs_to_cisu_no_rs_ri():
         "converter.cisu.resources_status.resources_status_converter.get_last_rs_ri_by_case_id",
         return_value=None,
     ):
-        result = ResourcesStatusConverter.from_rs_to_cisu(rs_sr_new)
-        assert result == []
+        with pytest.raises(ValueError, match="No RS-RI found for caseId"):
+            ResourcesStatusConverter.from_rs_to_cisu(rs_sr_new)


### PR DESCRIPTION
## 🔎 Détails

Lors de la réception d’un message RS-SR, si aucun message RS-RI persisté n’est trouvé pour le même caseId, le converter lève désormais une erreur explicite `ValueError`.


## 📄 Documentation

> Ajoutez un (des) lien(s) vers la documentation si nécessaire

## 📸 Captures d'écran

| Avant | Après |
| ----- | ----- |
|       |       |

## 🔗 Ticket associé

[A la réception d'un RS-SR, si aucun message RS-RI persisté n'est trouvé pour ce caseId, renvoyer une erreur.](https://app.asana.com/1/1201445755223134/project/1213699865754209/task/1213897272192855?focus=true)
