### PR TITLE
Fix : mise à jour du distributionId et du message Ie dans le flux de conversion du RC-RI

### DIFF
--- a/converter/converter/cisu/resources_info/resources_info_cisu_converter.py
+++ b/converter/converter/cisu/resources_info/resources_info_cisu_converter.py
@@ -70,8 +70,8 @@ class ResourcesInfoCISUConverter(BaseCISUConverter):
         )
         output_json = cls.copy_cisu_input_content(edxl_json)
 
-        # Generate a new distributionID for the RS-SR message
-        output_json["distributionID"] = f"{edxl_json['senderID']}_{uuid.uuid4()}"
+        # Set a new distributionID for the RS-SR message
+        cls.set_distribution_id(output_json, f"{edxl_json['senderID']}_{uuid.uuid4()}")
 
         output_use_case_json = {
             "caseId": case_id,

--- a/converter/converter/conversion_mixin.py
+++ b/converter/converter/conversion_mixin.py
@@ -7,6 +7,8 @@ class ConversionMixin:
     JSON_CONTENT_KEY = "jsonContent"
     EMBEDDED_JSON_CONTENT_KEY = "embeddedJsonContent"
     MESSAGE_KEY = "message"
+    EDXL_DISTRIBUTION_ID_KEY = "distributionID"
+    RC_DE_MESSAGE_ID_KEY = "messageId"
 
     @classmethod
     def _copy_input_content(
@@ -48,3 +50,14 @@ class ConversionMixin:
             cls.EMBEDDED_JSON_CONTENT_KEY
         ][cls.MESSAGE_KEY][message_type] = output_use_case_json
         return output_json
+
+    @classmethod
+    def set_distribution_id(
+        cls,
+        edxl_json: Dict[str, Any],
+        distribution_id: str,
+    ) -> None:
+        edxl_json[cls.EDXL_DISTRIBUTION_ID_KEY] = distribution_id
+        edxl_json[cls.CONTENT_KEY][0][cls.JSON_CONTENT_KEY][
+            cls.EMBEDDED_JSON_CONTENT_KEY
+        ][cls.MESSAGE_KEY][cls.RC_DE_MESSAGE_ID_KEY] = distribution_id

--- a/converter/tests/cisu/snapshots/snap_test_create_case_converter.py
+++ b/converter/tests/cisu/snapshots/snap_test_create_case_converter.py
@@ -28,7 +28,7 @@ snapshots[
       "jsonContent": {
         "embeddedJsonContent": {
           "message": {
-            "messageId": "2608323d-507d-4cbf-bf74-52007f8124ea",
+            "messageId": "fr.fire.sdisZ_2608323d-507d-4cbf-bf74-52007f8124ea",
             "sender": {
               "name": "sdisZ",
               "URI": "hubsante:fr.fire.sdisZ"
@@ -196,7 +196,7 @@ snapshots[
       "jsonContent": {
         "embeddedJsonContent": {
           "message": {
-            "messageId": "2608323d-507d-4cbf-bf74-52007f8124ea",
+            "messageId": "fr.fire.sdisZ_2608323d-507d-4cbf-bf74-52007f8124ea",
             "sender": {
               "name": "sdisZ",
               "URI": "hubsante:fr.fire.sdisZ"
@@ -364,7 +364,7 @@ snapshots[
       "jsonContent": {
         "embeddedJsonContent": {
           "message": {
-            "messageId": "2608323d-507d-4cbf-bf74-52007f8124ea",
+            "messageId": "fr.fire.sdisZ_2608323d-507d-4cbf-bf74-52007f8124ea",
             "sender": {
               "name": "sdisZ",
               "URI": "hubsante:fr.fire.sdisZ"
@@ -420,7 +420,7 @@ snapshots[
       "jsonContent": {
         "embeddedJsonContent": {
           "message": {
-            "messageId": "2608323d-507d-4cbf-bf74-52007f8124ea",
+            "messageId": "fr.health.samuA_2608323d-507d-4cbf-bf74-52007f8124ea",
             "sender": {
               "name": "samuA",
               "URI": "hubsante:fr.health.samuA"
@@ -638,7 +638,7 @@ snapshots[
       "jsonContent": {
         "embeddedJsonContent": {
           "message": {
-            "messageId": "2608323d-507d-4cbf-bf74-52007f8124ea",
+            "messageId": "fr.health.samuA_2608323d-507d-4cbf-bf74-52007f8124ea",
             "sender": {
               "name": "samuA",
               "URI": "hubsante:fr.health.samuA"
@@ -880,7 +880,7 @@ snapshots[
       "jsonContent": {
         "embeddedJsonContent": {
           "message": {
-            "messageId": "2608323d-507d-4cbf-bf74-52007f8124ea",
+            "messageId": "fr.health.samuA_2608323d-507d-4cbf-bf74-52007f8124ea",
             "sender": {
               "name": "samuA",
               "URI": "hubsante:fr.health.samuA"

--- a/converter/tests/cisu/snapshots/snap_test_reference_converter.py
+++ b/converter/tests/cisu/snapshots/snap_test_reference_converter.py
@@ -28,7 +28,7 @@ snapshots[
       "jsonContent": {
         "embeddedJsonContent": {
           "message": {
-            "messageId": "2608323d-507d-4cbf-bf74-52007f8124ea",
+            "messageId": "fr.health.samuA_2608323d-507d-4cbf-bf74-52007f8124ea",
             "sender": {
               "name": "samuA",
               "URI": "hubsante:fr.health.samuA"
@@ -76,7 +76,7 @@ snapshots[
       "jsonContent": {
         "embeddedJsonContent": {
           "message": {
-            "messageId": "2608323d-507d-4cbf-bf74-52007f8124ea",
+            "messageId": "fr.health.samuA_2608323d-507d-4cbf-bf74-52007f8124ea",
             "sender": {
               "name": "samuA",
               "URI": "hubsante:fr.health.samuA"

--- a/converter/tests/cisu/test_resources_info_converter.py
+++ b/converter/tests/cisu/test_resources_info_converter.py
@@ -245,16 +245,15 @@ def test_from_cisu_to_rs_new_case_id():
             f"message {i} must be a RS-SR (resourcesStatus key expected)"
         )
 
-    dist_ids = [msg["distributionID"] for msg in results]
-    message_ids = [
-        msg["content"][0]["jsonContent"]["embeddedJsonContent"]["message"]["messageId"]
-        for msg in results
-    ]
+    for msg in results:
+        dist_id = msg["distributionID"]
+        msg_id = msg["content"][0]["jsonContent"]["embeddedJsonContent"]["message"][
+            "messageId"
+        ]
 
-    for i in range(len(dist_ids)):
-        assert dist_ids[i] == message_ids[i], (
-            "distributionIDs and messageIds must be equal"
-        )
+        assert dist_id == msg_id, f"distributionID '{dist_id}' != messageId '{msg_id}'"
+
+    dist_ids = [msg["distributionID"] for msg in results]
     assert len(dist_ids) == len(set(dist_ids)), "all distributionIDs must be unique"
 
     resources_info = results[0]["content"][0]["jsonContent"]["embeddedJsonContent"][

--- a/converter/tests/cisu/test_resources_info_converter.py
+++ b/converter/tests/cisu/test_resources_info_converter.py
@@ -246,6 +246,15 @@ def test_from_cisu_to_rs_new_case_id():
         )
 
     dist_ids = [msg["distributionID"] for msg in results]
+    message_ids = [
+        msg["content"][0]["jsonContent"]["embeddedJsonContent"]["message"]["messageId"]
+        for msg in results
+    ]
+
+    for i in range(len(dist_ids)):
+        assert dist_ids[i] == message_ids[i], (
+            "distributionIDs and messageIds must be equal"
+        )
     assert len(dist_ids) == len(set(dist_ids)), "all distributionIDs must be unique"
 
     resources_info = results[0]["content"][0]["jsonContent"]["embeddedJsonContent"][

--- a/converter/tests/fixtures/EDXL/edxl_envelope_fire_to_health.json
+++ b/converter/tests/fixtures/EDXL/edxl_envelope_fire_to_health.json
@@ -18,7 +18,7 @@
         "jsonContent": {
           "embeddedJsonContent": {
             "message": {
-              "messageId": "2608323d-507d-4cbf-bf74-52007f8124ea",
+              "messageId": "fr.fire.sdisZ_2608323d-507d-4cbf-bf74-52007f8124ea",
               "sender": {
                 "name": "sdisZ",
                 "URI": "hubsante:fr.fire.sdisZ"

--- a/converter/tests/fixtures/EDXL/edxl_envelope_health_to_fire.json
+++ b/converter/tests/fixtures/EDXL/edxl_envelope_health_to_fire.json
@@ -18,7 +18,7 @@
         "jsonContent": {
           "embeddedJsonContent": {
             "message": {
-              "messageId": "2608323d-507d-4cbf-bf74-52007f8124ea",
+              "messageId": "fr.health.samuA_2608323d-507d-4cbf-bf74-52007f8124ea",
               "sender": {
                 "name": "samuA",
                 "URI": "hubsante:fr.health.samuA"

--- a/converter/tests/fixtures/EDXL/edxl_envelope_health_to_health.json
+++ b/converter/tests/fixtures/EDXL/edxl_envelope_health_to_health.json
@@ -18,7 +18,7 @@
         "jsonContent": {
           "embeddedJsonContent": {
             "message": {
-              "messageId": "2608323d-507d-4cbf-bf74-52007f8124ea",
+              "messageId": "fr.health.samuA_2608323d-507d-4cbf-bf74-52007f8124ea",
               "sender": {
                 "name": "samuA",
                 "URI": "hubsante:fr.health.samuA"

--- a/converter/tests/versions/create_health_case/snapshots/snap_test_v1_v2_converter.py
+++ b/converter/tests/versions/create_health_case/snapshots/snap_test_v1_v2_converter.py
@@ -26,7 +26,7 @@ snapshots["TestSnapshotV1V2Converter::test_snapshot_V1_to_V2_upgrade 1"] = """{
       "jsonContent": {
         "embeddedJsonContent": {
           "message": {
-            "messageId": "2608323d-507d-4cbf-bf74-52007f8124ea",
+            "messageId": "fr.health.samuA_2608323d-507d-4cbf-bf74-52007f8124ea",
             "sender": {
               "name": "samuA",
               "URI": "hubsante:fr.health.samuA"
@@ -354,7 +354,7 @@ snapshots["TestSnapshotV1V2Converter::test_snapshot_V2_to_V1_downgrade 1"] = """
       "jsonContent": {
         "embeddedJsonContent": {
           "message": {
-            "messageId": "2608323d-507d-4cbf-bf74-52007f8124ea",
+            "messageId": "fr.health.samuA_2608323d-507d-4cbf-bf74-52007f8124ea",
             "sender": {
               "name": "samuA",
               "URI": "hubsante:fr.health.samuA"

--- a/converter/tests/versions/create_health_case/snapshots/snap_test_v2_v3_converter.py
+++ b/converter/tests/versions/create_health_case/snapshots/snap_test_v2_v3_converter.py
@@ -26,7 +26,7 @@ snapshots["TestSnapshotV2V3Converter::test_snapshot_V2_to_V3_upgrade 1"] = """{
       "jsonContent": {
         "embeddedJsonContent": {
           "message": {
-            "messageId": "2608323d-507d-4cbf-bf74-52007f8124ea",
+            "messageId": "fr.health.samuA_2608323d-507d-4cbf-bf74-52007f8124ea",
             "sender": {
               "name": "samuA",
               "URI": "hubsante:fr.health.samuA"
@@ -416,7 +416,7 @@ snapshots["TestSnapshotV2V3Converter::test_snapshot_V3_to_V2_bis_downgrade 1"] =
       "jsonContent": {
         "embeddedJsonContent": {
           "message": {
-            "messageId": "2608323d-507d-4cbf-bf74-52007f8124ea",
+            "messageId": "fr.health.samuA_2608323d-507d-4cbf-bf74-52007f8124ea",
             "sender": {
               "name": "samuA",
               "URI": "hubsante:fr.health.samuA"
@@ -707,7 +707,7 @@ snapshots["TestSnapshotV2V3Converter::test_snapshot_V3_to_V2_downgrade 1"] = """
       "jsonContent": {
         "embeddedJsonContent": {
           "message": {
-            "messageId": "2608323d-507d-4cbf-bf74-52007f8124ea",
+            "messageId": "fr.health.samuA_2608323d-507d-4cbf-bf74-52007f8124ea",
             "sender": {
               "name": "samuA",
               "URI": "hubsante:fr.health.samuA"

--- a/converter/tests/versions/snapshots/snap_test_reference_converter.py
+++ b/converter/tests/versions/snapshots/snap_test_reference_converter.py
@@ -28,7 +28,7 @@ snapshots[
       "jsonContent": {
         "embeddedJsonContent": {
           "message": {
-            "messageId": "2608323d-507d-4cbf-bf74-52007f8124ea",
+            "messageId": "fr.health.samuA_2608323d-507d-4cbf-bf74-52007f8124ea",
             "sender": {
               "name": "samuA",
               "URI": "hubsante:fr.health.samuA"

--- a/converter/tests/versions/snapshots/snap_test_resources_info_converter.py
+++ b/converter/tests/versions/snapshots/snap_test_resources_info_converter.py
@@ -28,7 +28,7 @@ snapshots[
       "jsonContent": {
         "embeddedJsonContent": {
           "message": {
-            "messageId": "2608323d-507d-4cbf-bf74-52007f8124ea",
+            "messageId": "fr.health.samuA_2608323d-507d-4cbf-bf74-52007f8124ea",
             "sender": {
               "name": "samuA",
               "URI": "hubsante:fr.health.samuA"
@@ -115,7 +115,7 @@ snapshots[
       "jsonContent": {
         "embeddedJsonContent": {
           "message": {
-            "messageId": "2608323d-507d-4cbf-bf74-52007f8124ea",
+            "messageId": "fr.health.samuA_2608323d-507d-4cbf-bf74-52007f8124ea",
             "sender": {
               "name": "samuA",
               "URI": "hubsante:fr.health.samuA"
@@ -176,7 +176,7 @@ snapshots[
       "jsonContent": {
         "embeddedJsonContent": {
           "message": {
-            "messageId": "2608323d-507d-4cbf-bf74-52007f8124ea",
+            "messageId": "fr.health.samuA_2608323d-507d-4cbf-bf74-52007f8124ea",
             "sender": {
               "name": "samuA",
               "URI": "hubsante:fr.health.samuA"
@@ -228,7 +228,7 @@ snapshots[
       "jsonContent": {
         "embeddedJsonContent": {
           "message": {
-            "messageId": "2608323d-507d-4cbf-bf74-52007f8124ea",
+            "messageId": "fr.health.samuA_2608323d-507d-4cbf-bf74-52007f8124ea",
             "sender": {
               "name": "samuA",
               "URI": "hubsante:fr.health.samuA"
@@ -323,7 +323,7 @@ snapshots[
       "jsonContent": {
         "embeddedJsonContent": {
           "message": {
-            "messageId": "2608323d-507d-4cbf-bf74-52007f8124ea",
+            "messageId": "fr.health.samuA_2608323d-507d-4cbf-bf74-52007f8124ea",
             "sender": {
               "name": "samuA",
               "URI": "hubsante:fr.health.samuA"
@@ -376,7 +376,7 @@ snapshots[
       "jsonContent": {
         "embeddedJsonContent": {
           "message": {
-            "messageId": "2608323d-507d-4cbf-bf74-52007f8124ea",
+            "messageId": "fr.health.samuA_2608323d-507d-4cbf-bf74-52007f8124ea",
             "sender": {
               "name": "samuA",
               "URI": "hubsante:fr.health.samuA"
@@ -469,7 +469,7 @@ snapshots[
       "jsonContent": {
         "embeddedJsonContent": {
           "message": {
-            "messageId": "2608323d-507d-4cbf-bf74-52007f8124ea",
+            "messageId": "fr.health.samuA_2608323d-507d-4cbf-bf74-52007f8124ea",
             "sender": {
               "name": "samuA",
               "URI": "hubsante:fr.health.samuA"
@@ -576,7 +576,7 @@ snapshots[
       "jsonContent": {
         "embeddedJsonContent": {
           "message": {
-            "messageId": "2608323d-507d-4cbf-bf74-52007f8124ea",
+            "messageId": "fr.health.samuA_2608323d-507d-4cbf-bf74-52007f8124ea",
             "sender": {
               "name": "samuA",
               "URI": "hubsante:fr.health.samuA"
@@ -628,7 +628,7 @@ snapshots[
       "jsonContent": {
         "embeddedJsonContent": {
           "message": {
-            "messageId": "2608323d-507d-4cbf-bf74-52007f8124ea",
+            "messageId": "fr.health.samuA_2608323d-507d-4cbf-bf74-52007f8124ea",
             "sender": {
               "name": "samuA",
               "URI": "hubsante:fr.health.samuA"

--- a/converter/tests/versions/snapshots/snap_test_resources_request_converter.py
+++ b/converter/tests/versions/snapshots/snap_test_resources_request_converter.py
@@ -28,7 +28,7 @@ snapshots[
       "jsonContent": {
         "embeddedJsonContent": {
           "message": {
-            "messageId": "2608323d-507d-4cbf-bf74-52007f8124ea",
+            "messageId": "fr.health.samuA_2608323d-507d-4cbf-bf74-52007f8124ea",
             "sender": {
               "name": "samuA",
               "URI": "hubsante:fr.health.samuA"
@@ -82,7 +82,7 @@ snapshots[
       "jsonContent": {
         "embeddedJsonContent": {
           "message": {
-            "messageId": "2608323d-507d-4cbf-bf74-52007f8124ea",
+            "messageId": "fr.health.samuA_2608323d-507d-4cbf-bf74-52007f8124ea",
             "sender": {
               "name": "samuA",
               "URI": "hubsante:fr.health.samuA"
@@ -136,7 +136,7 @@ snapshots[
       "jsonContent": {
         "embeddedJsonContent": {
           "message": {
-            "messageId": "2608323d-507d-4cbf-bf74-52007f8124ea",
+            "messageId": "fr.health.samuA_2608323d-507d-4cbf-bf74-52007f8124ea",
             "sender": {
               "name": "samuA",
               "URI": "hubsante:fr.health.samuA"

--- a/converter/tests/versions/snapshots/snap_test_resources_response_converter.py
+++ b/converter/tests/versions/snapshots/snap_test_resources_response_converter.py
@@ -28,7 +28,7 @@ snapshots[
       "jsonContent": {
         "embeddedJsonContent": {
           "message": {
-            "messageId": "2608323d-507d-4cbf-bf74-52007f8124ea",
+            "messageId": "fr.health.samuA_2608323d-507d-4cbf-bf74-52007f8124ea",
             "sender": {
               "name": "samuA",
               "URI": "hubsante:fr.health.samuA"
@@ -80,7 +80,7 @@ snapshots[
       "jsonContent": {
         "embeddedJsonContent": {
           "message": {
-            "messageId": "2608323d-507d-4cbf-bf74-52007f8124ea",
+            "messageId": "fr.health.samuA_2608323d-507d-4cbf-bf74-52007f8124ea",
             "sender": {
               "name": "samuA",
               "URI": "hubsante:fr.health.samuA"
@@ -132,7 +132,7 @@ snapshots[
       "jsonContent": {
         "embeddedJsonContent": {
           "message": {
-            "messageId": "2608323d-507d-4cbf-bf74-52007f8124ea",
+            "messageId": "fr.health.samuA_2608323d-507d-4cbf-bf74-52007f8124ea",
             "sender": {
               "name": "samuA",
               "URI": "hubsante:fr.health.samuA"
@@ -184,7 +184,7 @@ snapshots[
       "jsonContent": {
         "embeddedJsonContent": {
           "message": {
-            "messageId": "2608323d-507d-4cbf-bf74-52007f8124ea",
+            "messageId": "fr.health.samuA_2608323d-507d-4cbf-bf74-52007f8124ea",
             "sender": {
               "name": "samuA",
               "URI": "hubsante:fr.health.samuA"
@@ -234,7 +234,7 @@ snapshots[
       "jsonContent": {
         "embeddedJsonContent": {
           "message": {
-            "messageId": "2608323d-507d-4cbf-bf74-52007f8124ea",
+            "messageId": "fr.health.samuA_2608323d-507d-4cbf-bf74-52007f8124ea",
             "sender": {
               "name": "samuA",
               "URI": "hubsante:fr.health.samuA"

--- a/converter/tests/versions/snapshots/snap_test_resources_status_converter.py
+++ b/converter/tests/versions/snapshots/snap_test_resources_status_converter.py
@@ -28,7 +28,7 @@ snapshots[
       "jsonContent": {
         "embeddedJsonContent": {
           "message": {
-            "messageId": "2608323d-507d-4cbf-bf74-52007f8124ea",
+            "messageId": "fr.health.samuA_2608323d-507d-4cbf-bf74-52007f8124ea",
             "sender": {
               "name": "samuA",
               "URI": "hubsante:fr.health.samuA"
@@ -79,7 +79,7 @@ snapshots[
       "jsonContent": {
         "embeddedJsonContent": {
           "message": {
-            "messageId": "2608323d-507d-4cbf-bf74-52007f8124ea",
+            "messageId": "fr.health.samuA_2608323d-507d-4cbf-bf74-52007f8124ea",
             "sender": {
               "name": "samuA",
               "URI": "hubsante:fr.health.samuA"
@@ -128,7 +128,7 @@ snapshots[
       "jsonContent": {
         "embeddedJsonContent": {
           "message": {
-            "messageId": "2608323d-507d-4cbf-bf74-52007f8124ea",
+            "messageId": "fr.health.samuA_2608323d-507d-4cbf-bf74-52007f8124ea",
             "sender": {
               "name": "samuA",
               "URI": "hubsante:fr.health.samuA"
@@ -179,7 +179,7 @@ snapshots[
       "jsonContent": {
         "embeddedJsonContent": {
           "message": {
-            "messageId": "2608323d-507d-4cbf-bf74-52007f8124ea",
+            "messageId": "fr.health.samuA_2608323d-507d-4cbf-bf74-52007f8124ea",
             "sender": {
               "name": "samuA",
               "URI": "hubsante:fr.health.samuA"
@@ -230,7 +230,7 @@ snapshots[
       "jsonContent": {
         "embeddedJsonContent": {
           "message": {
-            "messageId": "2608323d-507d-4cbf-bf74-52007f8124ea",
+            "messageId": "fr.health.samuA_2608323d-507d-4cbf-bf74-52007f8124ea",
             "sender": {
               "name": "samuA",
               "URI": "hubsante:fr.health.samuA"
@@ -280,7 +280,7 @@ snapshots[
       "jsonContent": {
         "embeddedJsonContent": {
           "message": {
-            "messageId": "2608323d-507d-4cbf-bf74-52007f8124ea",
+            "messageId": "fr.health.samuA_2608323d-507d-4cbf-bf74-52007f8124ea",
             "sender": {
               "name": "samuA",
               "URI": "hubsante:fr.health.samuA"
@@ -330,7 +330,7 @@ snapshots[
       "jsonContent": {
         "embeddedJsonContent": {
           "message": {
-            "messageId": "2608323d-507d-4cbf-bf74-52007f8124ea",
+            "messageId": "fr.health.samuA_2608323d-507d-4cbf-bf74-52007f8124ea",
             "sender": {
               "name": "samuA",
               "URI": "hubsante:fr.health.samuA"


### PR DESCRIPTION
## 🔎 Détails

Bug relevé : lors de la conversion RC-RI vers RS-RI+RS-SR, les messages pour lesquels un `distributionID` a été générés ne voient pas leur `messageId` dans le RC-DE modifié.

- Mise à jour des samples d'enveloppe EDXL pour que les valeurs des champs `messageId` matchent avec le format défini dans le DST 1.3 (identique au `distributionID`)
- Ajout d'un test sur l'égalité entre `distributionID` et `messageId` dans les messages générés par la conversion d'un RC-RI (test cassant)
- Fix de la mise à jour des ID grâce à une méthode `set_distribution_id`

## 🔗 Ticket associé

[Asana](https://app.asana.com/1/1201445755223134/project/1213699865754209/task/1213811002474159?focus=true)
