### PR TITLE
Feat/converter : Validation de la présence de la ressource RS-SR dans le RS-RI lors de la conversion

### DIFF
--- a/converter/converter/cisu/resources_info/resources_info_cisu_constants.py
+++ b/converter/converter/cisu/resources_info/resources_info_cisu_constants.py
@@ -4,6 +4,7 @@ class ResourcesInfoCISUConstants:
     VEHICLE_TYPE_PATH = "$.vehicleType"
 
     CASE_ID_FIELD = "caseId"
+    RESOURCE_ID_KEY = "resourceId"
     PATIENT_ID_KEY = "patientId"
     POSITION_KEY = "position"
 

--- a/converter/converter/cisu/resources_status/resources_status_constants.py
+++ b/converter/converter/cisu/resources_status/resources_status_constants.py
@@ -1,3 +1,4 @@
 class ResourcesStatusConstants:
     RESOURCE_STATUS_PATH = "$.resourceStatus"
     CASE_ID = "$.caseId"
+    RESOURCE_ID = "$.resourceId"

--- a/converter/converter/cisu/resources_status/resources_status_converter.py
+++ b/converter/converter/cisu/resources_status/resources_status_converter.py
@@ -39,11 +39,18 @@ class ResourcesStatusConverter(BaseCISUConverter):
         if rs_ri_msg is None:
             raise ValueError(f"No RS-RI found for caseId: {case_id!r}")
 
-        resource_id = get_field_value(current_use_case, ResourcesStatusConstants.RESOURCE_ID)
+        resource_id = get_field_value(
+            current_use_case, ResourcesStatusConstants.RESOURCE_ID
+        )
         rs_ri = rs_ri_msg.payload
         rs_ri_content = ResourcesInfoCISUConverter.copy_rs_input_use_case_content(rs_ri)
-        resources = get_field_value(rs_ri_content, ResourcesInfoCISUConstants.RESOURCE_PATH) or []
-        resource_ids_in_rs_ri = {r.get(ResourcesInfoCISUConstants.RESOURCE_ID_KEY) for r in resources}
+        resources = (
+            get_field_value(rs_ri_content, ResourcesInfoCISUConstants.RESOURCE_PATH)
+            or []
+        )
+        resource_ids_in_rs_ri = {
+            r.get(ResourcesInfoCISUConstants.RESOURCE_ID_KEY) for r in resources
+        }
 
         if resource_id not in resource_ids_in_rs_ri:
             raise ValueError(

--- a/converter/converter/cisu/resources_status/resources_status_converter.py
+++ b/converter/converter/cisu/resources_status/resources_status_converter.py
@@ -39,23 +39,8 @@ class ResourcesStatusConverter(BaseCISUConverter):
         if rs_ri_msg is None:
             raise ValueError(f"No RS-RI found for caseId: {case_id!r}")
 
-        resource_id = get_field_value(
-            current_use_case, ResourcesStatusConstants.RESOURCE_ID
-        )
         rs_ri = rs_ri_msg.payload
-        rs_ri_content = ResourcesInfoCISUConverter.copy_rs_input_use_case_content(rs_ri)
-        resources = (
-            get_field_value(rs_ri_content, ResourcesInfoCISUConstants.RESOURCE_PATH)
-            or []
-        )
-        resource_ids_in_rs_ri = {
-            r.get(ResourcesInfoCISUConstants.RESOURCE_ID_KEY) for r in resources
-        }
-
-        if resource_id not in resource_ids_in_rs_ri:
-            raise ValueError(
-                f"Resource '{resource_id}' from RS-SR not found in RS-RI for caseId '{case_id}'"
-            )
+        cls.check_resource_belongs_to_case(rs_ri, current_use_case)
 
         rs_sr_use_cases = [
             cls.copy_rs_input_use_case_content(pm.payload) for pm in persisted_rs_sr
@@ -69,3 +54,26 @@ class ResourcesStatusConverter(BaseCISUConverter):
         enriched = enrich_rs_ri_with_rs_srs(rs_ri_use_case, rs_sr_use_cases)
 
         return ResourcesInfoCISUConverter.convert_single_rs_ri(output_json, enriched)
+
+    @classmethod
+    def check_resource_belongs_to_case(
+        cls, rs_ri: Dict[str, Any], rs_sr_use_case: Dict[str, Any]
+    ) -> None:
+        case_id = get_field_value(rs_sr_use_case, ResourcesStatusConstants.CASE_ID)
+        resource_id = get_field_value(
+            rs_sr_use_case, ResourcesStatusConstants.RESOURCE_ID
+        )
+
+        rs_ri_content = ResourcesInfoCISUConverter.copy_rs_input_use_case_content(rs_ri)
+        resources = (
+            get_field_value(rs_ri_content, ResourcesInfoCISUConstants.RESOURCE_PATH)
+            or []
+        )
+        resource_ids_in_rs_ri = {
+            r.get(ResourcesInfoCISUConstants.RESOURCE_ID_KEY) for r in resources
+        }
+
+        if resource_id not in resource_ids_in_rs_ri:
+            raise ValueError(
+                f"Resource '{resource_id}' from RS-SR not found in RS-RI for caseId '{case_id}'"
+            )

--- a/converter/converter/cisu/resources_status/resources_status_converter.py
+++ b/converter/converter/cisu/resources_status/resources_status_converter.py
@@ -8,6 +8,9 @@ from converter.cisu.resources_info.resources_info_cisu_helper import (
 from converter.cisu.resources_info.resources_info_cisu_converter import (
     ResourcesInfoCISUConverter,
 )
+from converter.cisu.resources_info.resources_info_cisu_constants import (
+    ResourcesInfoCISUConstants,
+)
 from converter.cisu.resources_status.resources_status_constants import (
     ResourcesStatusConstants,
 )
@@ -36,7 +39,16 @@ class ResourcesStatusConverter(BaseCISUConverter):
         if rs_ri_msg is None:
             raise ValueError(f"No RS-RI found for caseId: {case_id!r}")
 
+        resource_id = get_field_value(current_use_case, ResourcesStatusConstants.RESOURCE_ID)
         rs_ri = rs_ri_msg.payload
+        rs_ri_content = ResourcesInfoCISUConverter.copy_rs_input_use_case_content(rs_ri)
+        resources = get_field_value(rs_ri_content, ResourcesInfoCISUConstants.RESOURCE_PATH) or []
+        resource_ids_in_rs_ri = {r.get(ResourcesInfoCISUConstants.RESOURCE_ID_KEY) for r in resources}
+
+        if resource_id not in resource_ids_in_rs_ri:
+            raise ValueError(
+                f"Resource '{resource_id}' from RS-SR not found in RS-RI for caseId '{case_id}'"
+            )
 
         rs_sr_use_cases = [
             cls.copy_rs_input_use_case_content(pm.payload) for pm in persisted_rs_sr

--- a/converter/tests/cisu/test_resources_status_converter.py
+++ b/converter/tests/cisu/test_resources_status_converter.py
@@ -1,5 +1,6 @@
 import pytest
 from unittest.mock import patch
+import pytest
 
 from converter.cisu.resources_status.resources_status_converter import (
     ResourcesStatusConverter,
@@ -75,3 +76,21 @@ def test_from_rs_to_cisu_no_rs_ri():
     ):
         with pytest.raises(ValueError, match="No RS-RI found for caseId"):
             ResourcesStatusConverter.from_rs_to_cisu(rs_sr_new)
+
+
+def test_from_rs_to_cisu_resource_not_in_rs_ri():
+    unknown_resource_id = "fr.fire.sis076.cgo-076.resource.UNKNOWN_VLM"
+    rs_sr = make_rs_sr(_CASE_ID, unknown_resource_id, "ARRIVEE")
+    rs_ri = make_rs_ri(_CASE_ID)  # RS-RI only has VLM1 and VLM2
+
+    with (
+        patch(
+            "converter.cisu.resources_status.resources_status_converter.get_last_rs_ri_by_case_id",
+            return_value=persisted(rs_ri),
+        ),
+        pytest.raises(
+            ValueError,
+            match=f"Resource '{unknown_resource_id}' from RS-SR not found in RS-RI for caseId '{_CASE_ID}'",
+        ),
+    ):
+        ResourcesStatusConverter.from_rs_to_cisu(rs_sr)

--- a/converter/tests/cisu/test_resources_status_converter.py
+++ b/converter/tests/cisu/test_resources_status_converter.py
@@ -1,6 +1,5 @@
 import pytest
 from unittest.mock import patch
-import pytest
 
 from converter.cisu.resources_status.resources_status_converter import (
     ResourcesStatusConverter,
@@ -80,13 +79,13 @@ def test_from_rs_to_cisu_no_rs_ri():
 
 def test_from_rs_to_cisu_resource_not_in_rs_ri():
     unknown_resource_id = "fr.fire.sis076.cgo-076.resource.UNKNOWN_VLM"
-    rs_sr = make_rs_sr(_CASE_ID, unknown_resource_id, "ARRIVEE")
-    rs_ri = make_rs_ri(_CASE_ID)  # RS-RI only has VLM1 and VLM2
+    rs_sr = make_rs_sr_from_sample(_CASE_ID, unknown_resource_id, "ARRIVEE")
+    rs_ri = make_rs_ri_from_sample(_CASE_ID)
 
     with (
         patch(
-            "converter.cisu.resources_status.resources_status_converter.get_last_rs_ri_by_case_id",
-            return_value=persisted(rs_ri),
+            _PATCH_GET_RS_MESSAGES,
+            return_value=persisted_rs_ri_and_rs_sr(rs_ri, []),
         ),
         pytest.raises(
             ValueError,


### PR DESCRIPTION
## 🔎 Détails

Ajout d’une validation lors de la conversion : lorsqu’un RS-SR est reçu, la ressource référencée doit exister dans le RS-RI correspondant, sinon une erreur explicite est retournée.

## 📄 Documentation

> Ajoutez un (des) lien(s) vers la documentation si nécessaire

## 📸 Captures d'écran

| Avant | Après |
| ----- | ----- |
|       |       |

## 🔗 Ticket associé

[A la réception d’un RS-SR, si la ressource n’est pas dans le RS-RI trouvé, retourner une erreur.](https://app.asana.com/1/1201445755223134/project/1213699865754209/task/1213897272192856?focus=true)
