### PR TITLE
Feat/refactor inplace conversion

### DIFF
--- a/converter/converter/cisu/resources_info/resources_info_cisu_converter.py
+++ b/converter/converter/cisu/resources_info/resources_info_cisu_converter.py
@@ -276,20 +276,6 @@ class ResourcesInfoCISUConverter(BaseCISUConverter):
             logger.debug("Processing resource: {resource}")
 
             try:
-                vehicle_type = cls.translate_to_cisu_vehicle_type(
-                    get_field_value(
-                        resource, ResourcesInfoCISUConstants.VEHICLE_TYPE_PATH
-                    )
-                )
-                if vehicle_type is None:
-                    continue
-
-                set_value(
-                    resource,
-                    ResourcesInfoCISUConstants.VEHICLE_TYPE_PATH,
-                    vehicle_type,
-                )
-
                 current_resource_path = (
                     f"{ResourcesInfoCISUConstants.RESOURCE_PATH}[{index}]"
                 )
@@ -300,8 +286,11 @@ class ResourcesInfoCISUConverter(BaseCISUConverter):
                     "Transforming state to singleton for CISU at path %s",
                     current_state_path,
                 )
-                cls.keep_last_state(resource)
-                delete_paths(resource, [ResourcesInfoCISUConstants.PATIENT_ID_KEY])
+
+                cls._translate_to_cisu_vehicle_type(resource)
+                cls._keep_last_state(resource)
+                cls._remove_patient_id(resource)
+
                 converted_resources.append(resource)
             except ConversionError:
                 continue
@@ -309,17 +298,41 @@ class ResourcesInfoCISUConverter(BaseCISUConverter):
         return converted_resources
 
     @classmethod
-    def translate_to_cisu_vehicle_type(cls, rs_vehicle_type: str) -> str | None:
-        """Translate a RS vehicle type to its CISU equivalent, or None if not mappable."""
-        if rs_vehicle_type.startswith(ResourcesInfoCISUConstants.VEHICLE_TYPE_SIS):
-            return ResourcesInfoCISUConstants.VEHICLE_TYPE_SIS
-        if rs_vehicle_type.startswith(ResourcesInfoCISUConstants.VEHICLE_TYPE_SMUR):
-            return ResourcesInfoCISUConstants.VEHICLE_TYPE_SMUR
-        logger.info("vehicleType '%s' is not mappable to CISU", rs_vehicle_type)
-        return None
+    def _remove_patient_id(cls, resource):
+        delete_paths(resource, [ResourcesInfoCISUConstants.PATIENT_ID_KEY])
 
     @classmethod
-    def keep_last_state(cls, resource: Dict[str, Any]) -> None:
+    def _translate_to_cisu_vehicle_type(cls, resource: Dict[str, Any]) -> None:
+        """Translate a RS vehicle type to its CISU equivalent, or None if not mappable."""
+
+        vehicle_type = get_field_value(
+            resource, ResourcesInfoCISUConstants.VEHICLE_TYPE_PATH
+        )
+
+        if vehicle_type is None:
+            raise ConversionError(
+                f"No vehicle found in RS resource for resource: {resource.get('resourceId')}."
+            )
+
+        if vehicle_type.startswith(ResourcesInfoCISUConstants.VEHICLE_TYPE_SIS):
+            set_value(
+                resource,
+                ResourcesInfoCISUConstants.VEHICLE_TYPE_PATH,
+                ResourcesInfoCISUConstants.VEHICLE_TYPE_SIS,
+            )
+        elif vehicle_type.startswith(ResourcesInfoCISUConstants.VEHICLE_TYPE_SMUR):
+            set_value(
+                resource,
+                ResourcesInfoCISUConstants.VEHICLE_TYPE_PATH,
+                ResourcesInfoCISUConstants.VEHICLE_TYPE_SMUR,
+            )
+        else:
+            raise ConversionError(
+                f"No valid vehicle found for resource: {resource.get('resourceId')}."
+            )
+
+    @classmethod
+    def _keep_last_state(cls, resource: Dict[str, Any]) -> None:
         states = get_field_value(resource, ResourcesInfoCISUConstants.STATE_PATH)
         if not states or len(states) == 0:
             raise ConversionError(

--- a/converter/tests/cisu/test_resources_info_converter.py
+++ b/converter/tests/cisu/test_resources_info_converter.py
@@ -5,6 +5,7 @@ from unittest.mock import patch
 import pytest
 
 from converter.cisu.resources_info.resources_info_cisu_converter import (
+    ConversionError,
     ResourcesInfoCISUConverter,
 )
 from tests.constants import TestConstants
@@ -120,21 +121,21 @@ class TestKeepLatestState(TestCase):
                 {"datetime": "2025-01-02T08:00:00Z"},
             ]
         }
-        ResourcesInfoCISUConverter.keep_last_state(resource)
+        ResourcesInfoCISUConverter._keep_last_state(resource)
 
         expected_resource = {"state": {"datetime": "2025-01-02T12:00:00Z"}}
 
         assert resource == expected_resource
 
     def test_keep_last_state_should_raise_exception_if_state_empty(self):
-        with pytest.raises(ValueError):
+        with pytest.raises(ConversionError):
             resource = {"state": []}
-            ResourcesInfoCISUConverter.keep_last_state(resource)
+            ResourcesInfoCISUConverter._keep_last_state(resource)
 
     def test_keep_last_state_should_raise_exception_if_state_undefined(self):
-        with pytest.raises(ValueError):
+        with pytest.raises(ConversionError):
             resource = {}
-            ResourcesInfoCISUConverter.keep_last_state(resource)
+            ResourcesInfoCISUConverter._keep_last_state(resource)
 
 
 def test_cisu_to_rs_breaking_changes():
@@ -164,16 +165,26 @@ def test_cisu_to_rs_breaking_changes():
         pytest.param("SIS.DRAGON", "SIS", id="translates SIS.DRAGON to SIS"),
         pytest.param("SMUR", "SMUR", id="translates SMUR to SMUR"),
         pytest.param("SMUR.VLM", "SMUR", id="translates SMUR.VLM to SMUR"),
-        pytest.param("AUTREVEC", None, id="AUTREVEC is not mappable to CISU"),
-        pytest.param("FSI.HELIFSI ", None, id="FSI.HELIFSI is not mappable to CISU"),
-        pytest.param("TSU.VSL", None, id="TSU.VSL is not mappable to CISU"),
     ],
 )
 def test_translate_vehicule_type_to_cisu(rs_vehicule_type, expected):
-    cisu_vehicle_type = ResourcesInfoCISUConverter.translate_to_cisu_vehicle_type(
-        rs_vehicule_type
-    )
-    assert cisu_vehicle_type == expected
+    resource = {"vehicleType": rs_vehicule_type}
+    ResourcesInfoCISUConverter._translate_to_cisu_vehicle_type(resource)
+    assert resource["vehicleType"] == expected
+
+
+@pytest.mark.parametrize(
+    "rs_vehicule_type",
+    [
+        pytest.param("AUTREVEC", id="AUTREVEC is not mappable to CISU"),
+        pytest.param("FSI.HELIFSI", id="FSI.HELIFSI is not mappable to CISU"),
+        pytest.param("TSU.VSL", id="TSU.VSL is not mappable to CISU"),
+    ],
+)
+def test_translate_vehicule_type_to_cisu_raises_on_unmappable(rs_vehicule_type):
+    resource = {"vehicleType": rs_vehicule_type}
+    with pytest.raises(ConversionError):
+        ResourcesInfoCISUConverter._translate_to_cisu_vehicle_type(resource)
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## 🔎 Détails

Dans le code de conversion, la conversion du message était parfois faite in place, parfois faite directement dans la méthode mère. 
Il y a donc maintenant : 

- une fonction dédiée `_translate_to_cisu_vehicle_type` : était déjà en place mais retournait un vehicleType, maintenant s'occupe de gérer le `set_value`
- une fonction `_keep_last_state` : était déjà en place
- une nouvelle fonction `_remove_patient_id`


## 🔗 Ticket associé

[refactor de la fonction _convert_resources_to_cisu](https://app.asana.com/1/1201445755223134/project/1213699865754209/task/1214054317988313?focus=true)
