### PR TITLE
feat(converter): distributionIDs logging during enrichment

### DIFF
--- a/converter/converter/cisu/resources_info/resources_info_cisu_converter.py
+++ b/converter/converter/cisu/resources_info/resources_info_cisu_converter.py
@@ -227,19 +227,24 @@ class ResourcesInfoCISUConverter(BaseCISUConverter):
 
         logger.info("Converting from RS to CISU format for Resources Info message.")
         logger.debug(f"Message content: {edxl_json}")
+
+        logger.info(
+            "Received RS-RI message with distributionID: %s for CISU conversion",
+            edxl_json.get("distributionID"),
+        )
+
         output_json = cls.copy_rs_input_content(edxl_json)
         current_use_case = cls.copy_rs_input_use_case_content(edxl_json)
 
         case_id = get_field_value(current_use_case, "caseId")
 
         _, persisted_rs_sr = get_rs_messages_by_case_id(case_id)
-        rs_sr_use_cases = [
-            # Hardcoded RS_SR use case to avoid circular dependency
-            # TODO: Fix
-            cls._copy_input_use_case_content(pm.payload, "resourcesStatus")
-            for pm in persisted_rs_sr
-        ]
-        enriched = enrich_rs_ri_with_rs_srs(current_use_case, rs_sr_use_cases)
+        rs_sr_edxls = [pm.payload for pm in persisted_rs_sr]
+
+        enriched = enrich_rs_ri_with_rs_srs(
+            rs_ri_edxl=edxl_json,
+            rs_sr_edxl_list=rs_sr_edxls,
+        )
 
         return cls.convert_single_rs_ri(output_json, enriched)
 

--- a/converter/converter/cisu/resources_info/resources_info_cisu_helper.py
+++ b/converter/converter/cisu/resources_info/resources_info_cisu_helper.py
@@ -1,3 +1,4 @@
+from converter.conversion_mixin import ConversionMixin
 from converter.utils import get_field_value, set_value
 from converter.cisu.resources_info.resources_info_cisu_constants import (
     ResourcesInfoCISUConstants,
@@ -6,26 +7,61 @@ import logging
 
 logger = logging.getLogger(__name__)
 
+_DISTRIBUTION_ID_KEY = ConversionMixin.EDXL_DISTRIBUTION_ID_KEY
 
-def enrich_rs_ri_with_rs_srs(rs_ri: dict, rs_sr_list: list[dict]) -> dict:
-    """Enrich RS-RI resources with state from a list of RS-SR messages (in-place + return)."""
 
-    if not rs_sr_list:
-        return rs_ri
+def enrich_rs_ri_with_rs_srs(
+    rs_ri_edxl: dict,
+    rs_sr_edxl_list: list[dict],
+) -> dict:
+    """Enrich RS-RI resources with state from RS-SR messages.
+    Receives full EDXL envelopes, extracts use cases and distribution IDs internally.
+    Centralizes all distribution-ID logging for both RS-RI and RS-SR conversion flows.
+    """
+    rs_ri_distribution_id = rs_ri_edxl.get(_DISTRIBUTION_ID_KEY)
+    rs_sr_distribution_ids = [sr.get(_DISTRIBUTION_ID_KEY) for sr in rs_sr_edxl_list]
 
-    rs_ri_resources = get_field_value(rs_ri, ResourcesInfoCISUConstants.RESOURCE_PATH)
-    sr_by_resource_id = {sr.get("resourceId"): sr for sr in rs_sr_list}
+    logger.info(
+        "Persisted RS-SRs found for RS-RI message with distributionID: %s -> %s",
+        rs_ri_distribution_id,
+        rs_sr_distribution_ids,
+    )
+
+    rs_ri_use_case = ConversionMixin._copy_input_use_case_content(
+        rs_ri_edxl, "resourcesInfo"
+    )
+
+    if not rs_sr_edxl_list:
+        return rs_ri_use_case
+
+    rs_sr_entries = [
+        (
+            ConversionMixin._copy_input_use_case_content(sr, "resourcesStatus"),
+            sr.get(_DISTRIBUTION_ID_KEY),
+        )
+        for sr in rs_sr_edxl_list
+    ]
+    sr_by_resource_id = {
+        use_case.get("resourceId"): (use_case, dist_id)
+        for use_case, dist_id in rs_sr_entries
+    }
+
+    rs_ri_resources = get_field_value(
+        rs_ri_use_case, ResourcesInfoCISUConstants.RESOURCE_PATH
+    )
+    used_sr_distribution_ids = []
 
     for resource in rs_ri_resources:
         resource_id = resource.get("resourceId")
-        persisted_sr = sr_by_resource_id.get(resource_id)
-        if persisted_sr is None:
+        entry = sr_by_resource_id.get(resource_id)
+        if entry is None:
             continue
 
+        persisted_sr, sr_dist_id = entry
         persisted_state = persisted_sr.get("state")
         if persisted_state is None:
             logger.warning(
-                f"No state found in persisted rs-sr for resourceId: {resource_id}"
+                "No state found in persisted RS-SR for resourceId: %s", resource_id
             )
             continue
 
@@ -38,7 +74,6 @@ def enrich_rs_ri_with_rs_srs(rs_ri: dict, rs_sr_list: list[dict]) -> dict:
                 ResourcesInfoCISUConstants.STATE_PATH,
                 [persisted_state],
             )
-
         else:
             latest_state = get_latest_state([*current_states, persisted_state])
             set_value(
@@ -47,7 +82,16 @@ def enrich_rs_ri_with_rs_srs(rs_ri: dict, rs_sr_list: list[dict]) -> dict:
                 [latest_state],
             )
 
-    return rs_ri
+        used_sr_distribution_ids.append(sr_dist_id)
+
+    logger.info(
+        "Enriched RS-RI (%s) with %s RS-SR (%s) before conversion",
+        rs_ri_distribution_id,
+        len(used_sr_distribution_ids),
+        used_sr_distribution_ids,
+    )
+
+    return rs_ri_use_case
 
 
 def get_latest_state(states: list[dict]) -> dict:

--- a/converter/converter/cisu/resources_status/resources_status_converter.py
+++ b/converter/converter/cisu/resources_status/resources_status_converter.py
@@ -15,6 +15,10 @@ from typing import Any, Dict
 
 from converter.utils import get_field_value
 
+import logging
+
+logger = logging.getLogger(__name__)
+
 
 class ResourcesStatusConverter(BaseCISUConverter):
     @classmethod
@@ -29,6 +33,11 @@ class ResourcesStatusConverter(BaseCISUConverter):
     def from_rs_to_cisu(
         cls, edxl_json: Dict[str, Any]
     ) -> Dict[str, Any] | list[Dict[str, Any]]:
+        logger.info(
+            "Received RS-SR message with distributionID: %s for CISU conversion",
+            edxl_json.get("distributionID"),
+        )
+
         current_use_case = cls.copy_rs_input_use_case_content(edxl_json)
         case_id = get_field_value(current_use_case, ResourcesStatusConstants.CASE_ID)
 
@@ -38,15 +47,14 @@ class ResourcesStatusConverter(BaseCISUConverter):
 
         rs_ri = rs_ri_msg.payload
 
-        rs_sr_use_cases = [
-            cls.copy_rs_input_use_case_content(pm.payload) for pm in persisted_rs_sr
-        ]
-        rs_sr_use_cases.append(current_use_case)
+        rs_sr_edxl_list = [pm.payload for pm in persisted_rs_sr]
+        rs_sr_edxl_list.append(edxl_json)
 
         output_json = ResourcesInfoCISUConverter.copy_rs_input_content(rs_ri)
-        rs_ri_use_case = ResourcesInfoCISUConverter.copy_rs_input_use_case_content(
-            rs_ri
+
+        enriched = enrich_rs_ri_with_rs_srs(
+            rs_ri_edxl=rs_ri,
+            rs_sr_edxl_list=rs_sr_edxl_list,
         )
-        enriched = enrich_rs_ri_with_rs_srs(rs_ri_use_case, rs_sr_use_cases)
 
         return ResourcesInfoCISUConverter.convert_single_rs_ri(output_json, enriched)

--- a/converter/tests/cisu/test_resources_info_cisu_helper.py
+++ b/converter/tests/cisu/test_resources_info_cisu_helper.py
@@ -3,9 +3,31 @@ from converter.cisu.resources_info.resources_info_cisu_helper import (
 )
 
 
-def _make_rs_ri(resources: list[dict]) -> dict:
-    """Wrap a resource list in a minimal RS-RI use-case dict."""
-    return {"resource": resources}
+def _wrap_edxl(
+    use_case: dict, message_type: str, distribution_id: str = "dist-test"
+) -> dict:
+    """Wrap a use-case dict in a minimal EDXL envelope."""
+    return {
+        "distributionID": distribution_id,
+        "content": [
+            {
+                "jsonContent": {
+                    "embeddedJsonContent": {"message": {message_type: use_case}}
+                }
+            }
+        ],
+    }
+
+
+def _make_rs_ri_edxl(resources: list[dict], distribution_id: str = "dist-ri") -> dict:
+    """Wrap a resource list in a minimal RS-RI EDXL envelope."""
+
+    return _wrap_edxl({"resource": resources}, "resourcesInfo", distribution_id)
+
+
+def _make_rs_sr_edxl(use_case: dict, distribution_id: str = "dist-sr") -> dict:
+    """Wrap an RS-SR use-case in a minimal EDXL envelope."""
+    return _wrap_edxl(use_case, "resourcesStatus", distribution_id)
 
 
 def test_no_persisted_rs_sr():
@@ -15,16 +37,14 @@ def test_no_persisted_rs_sr():
     ne pas modifier la ressource originale.
     """
 
-    rs_ri = _make_rs_ri(
+    rs_ri_edxl = _make_rs_ri_edxl(
         [
             {"resourceId": "r1"},
             {"resourceId": "r2"},
         ]
     )
 
-    rs_sr_list = []
-
-    result = enrich_rs_ri_with_rs_srs(rs_ri, rs_sr_list)
+    result = enrich_rs_ri_with_rs_srs(rs_ri_edxl, [])
 
     assert result is not None
     assert result["resource"][0] == {"resourceId": "r1"}
@@ -38,19 +58,19 @@ def test_no_current_state_but_persisted_rs_sr():
     remplacer le status de la ressource original par celui de la ressource persistée
     """
 
-    rs_ri = _make_rs_ri(
+    rs_ri_edxl = _make_rs_ri_edxl(
         [
             {"resourceId": "r1"},
             {"resourceId": "r2"},
         ]
     )
 
-    rs_sr_list = [
-        {"resourceId": "r1", "state": {"status": "OK"}},
-        {"resourceId": "r2", "state": {"status": "KO"}},
+    rs_sr_edxl_list = [
+        _make_rs_sr_edxl({"resourceId": "r1", "state": {"status": "OK"}}, "dist-sr-1"),
+        _make_rs_sr_edxl({"resourceId": "r2", "state": {"status": "KO"}}, "dist-sr-2"),
     ]
 
-    result = enrich_rs_ri_with_rs_srs(rs_ri, rs_sr_list)
+    result = enrich_rs_ri_with_rs_srs(rs_ri_edxl, rs_sr_edxl_list)
 
     assert result is not None
     assert result["resource"][0]["state"] == [{"status": "OK"}]
@@ -64,7 +84,7 @@ def test_current_state_and_persisted_rs_sr():
     remplacer le status de la ressource original par le status le plus récent en se basant sur le champ datetime contenu dans le status.
     """
 
-    rs_ri = _make_rs_ri(
+    rs_ri_edxl = _make_rs_ri_edxl(
         [
             {
                 "resourceId": "r1",
@@ -79,18 +99,27 @@ def test_current_state_and_persisted_rs_sr():
         ]
     )
 
-    rs_sr_list = [
-        {
-            "resourceId": "r1",
-            "state": {"status": "PENDING2", "datetime": "2025-05-18T17:00:00+02:00"},
-        },
-        {
-            "resourceId": "r2",
-            "state": {"status": "DONE2", "datetime": "2025-05-18T20:00:00+02:00"},
-        },
+    rs_sr_edxl_list = [
+        _make_rs_sr_edxl(
+            {
+                "resourceId": "r1",
+                "state": {
+                    "status": "PENDING2",
+                    "datetime": "2025-05-18T17:00:00+02:00",
+                },
+            },
+            "dist-sr-1",
+        ),
+        _make_rs_sr_edxl(
+            {
+                "resourceId": "r2",
+                "state": {"status": "DONE2", "datetime": "2025-05-18T20:00:00+02:00"},
+            },
+            "dist-sr-2",
+        ),
     ]
 
-    result = enrich_rs_ri_with_rs_srs(rs_ri, rs_sr_list)
+    result = enrich_rs_ri_with_rs_srs(rs_ri_edxl, rs_sr_edxl_list)
 
     assert result is not None
     assert result["resource"][0]["state"][0]["status"] == "PENDING"


### PR DESCRIPTION
## 🔎 Détails

Les distributionId des différents messages se trouvent directement dans l’enveloppe edxl, pas dans le case.

Pour pouvoir permettre de les logger à un seul endroit, on doit faire l’extraction ET le logging dans la méthode `enrich_rs_ri_with_rs_srs`.

Ça implique de passer du exdl directement dans la méthode `enrich_rs_ri_with_rs_srs`.

Cette PR fait donc :
- la mise à jour de `enrich_rs_ri_with_rs_srs`,  qui fait l'extraction des cases, et fait le logging
- met à jour l'utilisation de enrich_rs_ri_with_rs_srs dans les méthodes `from_rs_to_cisu` pour passer en paramètre du edxl
- met à jour les tests `enrich_rs_ri_with_rs_srs`

## 📸 Captures d'écran

<img width="978" height="567" alt="image" src="https://github.com/user-attachments/assets/24807a75-fb47-41bb-9eef-3bd4b02467d9" />

## 🔗 Ticket associé

[Asana](https://app.asana.com/1/1201445755223134/project/1213699865754209/task/1213897272192858?focus=true)
