### PR TITLE
Converter : transmission du distributionID original pour la conversion RC-RI dans le sens 18-15

### DIFF
--- a/.github/workflows/converter-tests.yml
+++ b/.github/workflows/converter-tests.yml
@@ -65,7 +65,7 @@ jobs:
 
 
       - name: Pytest coverage comment
-        uses: MishaKav/pytest-coverage-comment@v1.1.53
+        uses: MishaKav/pytest-coverage-comment@v1.7.1
         with:
           pytest-xml-coverage-path: ./converter/coverage.xml
           title: "Converter - python code coverage"

--- a/.github/workflows/converter-tests.yml
+++ b/.github/workflows/converter-tests.yml
@@ -63,11 +63,6 @@ jobs:
           path: tools/converter/htmlcov
           retention-days: 7
 
-      - name: Run ReportGenerator for test coverage
-        uses: danielpalme/ReportGenerator-GitHub-Action@5.1.23
-        with:
-          reports: ./converter/coverage.xml
-          targetdir: coveragereport
 
       - name: Pytest coverage comment
         uses: MishaKav/pytest-coverage-comment@v1.1.53

--- a/converter/converter/cisu/resources_info/resources_info_cisu_converter.py
+++ b/converter/converter/cisu/resources_info/resources_info_cisu_converter.py
@@ -73,7 +73,11 @@ class ResourcesInfoCISUConverter(BaseCISUConverter):
 
     @classmethod
     def _build_rs_sr_from_resource(
-        cls, edxl_json: Dict[str, Any], resource: Dict[str, Any], case_id: str
+        cls,
+        edxl_json: Dict[str, Any],
+        resource: Dict[str, Any],
+        case_id: str,
+        use_original_distribution_id: bool = False,
     ) -> Dict[str, Any]:
         """Build an RS-SR from a single RC-RI resource, reusing the EDXL envelope."""
         logger.info(
@@ -83,8 +87,10 @@ class ResourcesInfoCISUConverter(BaseCISUConverter):
         )
         output_json = cls.copy_cisu_input_content(edxl_json)
 
-        # Set a new distributionID for the RS-SR message
-        cls.set_distribution_id(output_json, f"{edxl_json['senderID']}_{uuid.uuid4()}")
+        if not use_original_distribution_id:
+            cls.set_distribution_id(
+                output_json, f"{edxl_json['senderID']}_{uuid.uuid4()}"
+            )
 
         output_use_case_json = {
             "caseId": case_id,
@@ -200,12 +206,17 @@ class ResourcesInfoCISUConverter(BaseCISUConverter):
             rs_ri = cls._build_rs_ri_from_cisu(edxl_json)
             messages.append(rs_ri)
 
-        for resource in modified_status_resources:
+        for idx, resource in enumerate(modified_status_resources):
             logger.info(
                 "Resource %s has a modified status — adding RS-SR to output.",
                 resource.get("resourceId"),
             )
-            rs_sr = cls._build_rs_sr_from_resource(edxl_json, resource, case_id)
+            should_use_original_distribution_id = (
+                not engaged_resources_updated and idx == 0
+            )
+            rs_sr = cls._build_rs_sr_from_resource(
+                edxl_json, resource, case_id, should_use_original_distribution_id
+            )
             messages.append(rs_sr)
 
         if not messages:

--- a/converter/tests/cisu/test_resources_info_converter.py
+++ b/converter/tests/cisu/test_resources_info_converter.py
@@ -237,6 +237,9 @@ def test_from_cisu_to_rs_new_case_id():
     assert "resourcesInfo" in first_message, (
         "first message must be a RS-RI (resourcesInfo key expected)"
     )
+    assert results[0]["distributionID"] == RC_RI_WITH_POSITION_EDXL["distributionID"], (
+        "Converted RS-RI doesn't have the same distributionID as original RC-RI"
+    )
 
     for i, rs_sr in enumerate(results[1:], start=1):
         message = get_edxl_message(rs_sr)
@@ -393,6 +396,10 @@ def test_from_cisu_to_rs_known_case_id_status_changed_only():
 
     assert isinstance(results, list), "from_cisu_to_rs must return a list"
     assert len(results) == 1, f"expected 1 RS-SR, got {len(results)}"
+    assert results[0]["distributionID"] == RC_RI_WITH_POSITION_EDXL["distributionID"], (
+        "Converted RS-SR doesn't have the same distributionID as original RC-RI"
+    )
+
     message = get_edxl_message(results[0])
     assert "resourcesStatus" in message, "expected RS-SR (resourcesStatus key)"
     assert "resourcesInfo" not in message, (
@@ -421,6 +428,9 @@ def test_from_cisu_to_rs_known_case_id_resource_added():
 
     assert isinstance(results, list), "from_cisu_to_rs must return a list"
     assert len(results) == 2, f"expected RS-RI + RS-SR, got {len(results)}"
+    assert results[0]["distributionID"] == RC_RI_WITH_POSITION_EDXL["distributionID"], (
+        "Converted RS-RI doesn't have the same distributionID as original RC-RI"
+    )
 
     first_message = get_edxl_message(results[0])
     assert "resourcesInfo" in first_message, (


### PR DESCRIPTION
## 🔎 Détails

- Ajout du distributionID du message RC-RI original dans les messages convertis
- Prise en compte des 2 cas : 
  - si un RS-RI est généré, on lui fait porter le distributionID du message original
  - si aucun RS-RI n'est généré, le premier RS-SR généré porte le distributionID du message original

Chore :
- Suppression d'une étape de post du coverage dans la PR présente en double dans la CI
- Bump à la version latest de l'action de post du coverage

## 🔗 Ticket associé

[Asana](https://app.asana.com/1/1201445755223134/project/1213699865754209/task/1214024839956825?focus=true)
