### PR TITLE
Feat/cisu to rs logging

### DIFF
--- a/converter/converter/cisu/resources_info/resources_info_cisu_converter.py
+++ b/converter/converter/cisu/resources_info/resources_info_cisu_converter.py
@@ -9,6 +9,7 @@ from converter.cisu.resources_info.resources_info_cisu_constants import (
 from converter.cisu.resources_info.resources_info_cisu_helper import (
     enrich_rs_ri_with_rs_srs,
     get_latest_state,
+    log_cisu_to_rs_converted_messages_ids,
 )
 from converter.repositories.message_repository import (
     get_last_rc_ri_by_case_id,
@@ -181,6 +182,9 @@ class ResourcesInfoCISUConverter(BaseCISUConverter):
                 converted_messages.append(
                     cls._build_rs_sr_from_resource(edxl_json, resource, case_id)
                 )
+            log_cisu_to_rs_converted_messages_ids(
+                edxl_json, converted_messages[0], converted_messages[1:]
+            )
             return converted_messages
 
         # Known caseId — compare resources and emit only what changed
@@ -196,15 +200,16 @@ class ResourcesInfoCISUConverter(BaseCISUConverter):
             "modified_status_resources"
         ]
 
-        messages: List[Dict[str, Any]] = []
+        converted_rs_ri = None
 
         if engaged_resources_updated:
             logger.info(
                 "Resources added/removed for caseId %s — adding RS-RI to output.",
                 case_id,
             )
-            rs_ri = cls._build_rs_ri_from_cisu(edxl_json)
-            messages.append(rs_ri)
+            converted_rs_ri = cls._build_rs_ri_from_cisu(edxl_json)
+
+        converted_rs_sr_messages: List[Dict[str, Any]] = []
 
         for idx, resource in enumerate(modified_status_resources):
             logger.info(
@@ -217,12 +222,18 @@ class ResourcesInfoCISUConverter(BaseCISUConverter):
             rs_sr = cls._build_rs_sr_from_resource(
                 edxl_json, resource, case_id, should_use_original_distribution_id
             )
-            messages.append(rs_sr)
+            converted_rs_sr_messages.append(rs_sr)
 
-        if not messages:
-            logger.info("No resource changes detected for caseId %s.", case_id)
+        converted_messages = []
+        if converted_rs_ri is not None:
+            converted_messages.append(converted_rs_ri)
+        converted_messages += converted_rs_sr_messages
 
-        return messages
+        log_cisu_to_rs_converted_messages_ids(
+            edxl_json, converted_rs_ri, converted_rs_sr_messages
+        )
+
+        return converted_messages
 
     @classmethod
     def from_rs_to_cisu(cls, edxl_json: Dict[str, Any]) -> Dict[str, Any]:

--- a/converter/converter/cisu/resources_info/resources_info_cisu_helper.py
+++ b/converter/converter/cisu/resources_info/resources_info_cisu_helper.py
@@ -97,3 +97,26 @@ def enrich_rs_ri_with_rs_srs(
 def get_latest_state(states: list[dict]) -> dict:
     """Return the state with the most recent datetime from a list of states."""
     return sorted(states, key=lambda x: x.get("datetime", ""))[-1]
+
+
+def log_cisu_to_rs_converted_messages_ids(
+    original_message: dict, rs_ri: dict | None, rs_sr_list: list[dict]
+) -> None:
+    if rs_ri is None and len(rs_sr_list) == 0:
+        logger.info(
+            f"No RS message produced when converting RC-RI with distributionId {original_message.get('distributionID')}."
+        )
+
+    else:
+        log_message = f"Converted RC-RI with distributionID {original_message.get('distributionID')} into"
+
+        if rs_ri is not None:
+            log_message += f" RS-RI {rs_ri.get('distributionID')}"
+
+        if rs_sr_list:
+            if rs_ri is not None:
+                log_message += " and"
+            rs_sr_ids = [rs_sr.get("distributionID") for rs_sr in rs_sr_list]
+            log_message += f" {len(rs_sr_list)} RS-SR(s) {rs_sr_ids}"
+
+        logger.info(log_message)

--- a/converter/tests/cisu/test_resources_info_cisu_helper.py
+++ b/converter/tests/cisu/test_resources_info_cisu_helper.py
@@ -1,5 +1,6 @@
 from converter.cisu.resources_info.resources_info_cisu_helper import (
     enrich_rs_ri_with_rs_srs,
+    log_cisu_to_rs_converted_messages_ids,
 )
 
 
@@ -124,3 +125,58 @@ def test_current_state_and_persisted_rs_sr():
     assert result is not None
     assert result["resource"][0]["state"][0]["status"] == "PENDING"
     assert result["resource"][1]["state"][0]["status"] == "DONE2"
+
+
+class TestLogCisuToRsConvertedMessagesIds:
+    def test_with_rs_ri_and_rs_srs(self, caplog):
+        original = {"distributionID": "orig-123"}
+        rs_ri = {"distributionID": "ri-456"}
+        rs_sr_list = [
+            {"distributionID": "sr-1"},
+            {"distributionID": "sr-2"},
+        ]
+
+        with caplog.at_level("INFO"):
+            log_cisu_to_rs_converted_messages_ids(original, rs_ri, rs_sr_list)
+
+        assert len(caplog.records) == 1
+        assert caplog.records[0].message == (
+            "Converted RC-RI with distributionID orig-123 into RS-RI ri-456 and 2 RS-SR(s) ['sr-1', 'sr-2']"
+        )
+
+    def test_without_rs_ri(self, caplog):
+        original = {"distributionID": "orig-123"}
+        rs_sr_list = [
+            {"distributionID": "sr-1"},
+        ]
+
+        with caplog.at_level("INFO"):
+            log_cisu_to_rs_converted_messages_ids(original, None, rs_sr_list)
+
+        assert len(caplog.records) == 1
+        assert caplog.records[0].message == (
+            "Converted RC-RI with distributionID orig-123 into 1 RS-SR(s) ['sr-1']"
+        )
+
+    def test_with_rs_ri_and_no_rs_srs(self, caplog):
+        original = {"distributionID": "orig-123"}
+        rs_ri = {"distributionID": "ri-456"}
+
+        with caplog.at_level("INFO"):
+            log_cisu_to_rs_converted_messages_ids(original, rs_ri, [])
+
+        assert len(caplog.records) == 1
+        assert caplog.records[0].message == (
+            "Converted RC-RI with distributionID orig-123 into RS-RI ri-456"
+        )
+
+    def test_without_rs_ri_and_no_rs_srs(self, caplog):
+        original = {"distributionID": "orig-123"}
+
+        with caplog.at_level("INFO"):
+            log_cisu_to_rs_converted_messages_ids(original, None, [])
+
+        assert len(caplog.records) == 1
+        assert caplog.records[0].message == (
+            "No RS message produced when converting RC-RI with distributionId orig-123."
+        )


### PR DESCRIPTION
## 🔎 Détails

Ajout de logs explicites dans la conversion cisu to rs.
-  ajout d'une nouvelle méthode `log_cisu_to_rs_converted_messages_ids`

## 🔗 Ticket associé

[Asana](https://app.asana.com/1/1201445755223134/project/1213699865754209/task/1213897272192857?focus=true)
