### PR TITLE
fix(converter) : Corrige la source du distributionID en conversion RS-SR

### DIFF
--- a/converter/converter/cisu/resources_status/resources_status_converter.py
+++ b/converter/converter/cisu/resources_status/resources_status_converter.py
@@ -54,7 +54,7 @@ class ResourcesStatusConverter(BaseCISUConverter):
         rs_sr_edxl_list = [pm.payload for pm in persisted_rs_sr]
         rs_sr_edxl_list.append(edxl_json)
 
-        output_json = ResourcesInfoCISUConverter.copy_rs_input_content(rs_ri)
+        output_json = cls.copy_rs_input_content(edxl_json)
 
         enriched = enrich_rs_ri_with_rs_srs(
             rs_ri_edxl=rs_ri,

--- a/converter/tests/cisu/test_resources_status_converter.py
+++ b/converter/tests/cisu/test_resources_status_converter.py
@@ -51,6 +51,8 @@ def test_from_rs_to_cisu_real_data():
     assert result is not None
     assert result != []
 
+    assert result["distributionID"] == rs_sr_new["distributionID"]
+
     resources = get_cisu_resources(result)
 
     assert len(resources) == 2


### PR DESCRIPTION
## 🔎 Détails

La construction de l’enveloppe de sortie pour la conversion RS-SR -> RC-RI utilise désormais l’enveloppe du RS-SR entrant (et non celle du RS-RI persisté).

## 📄 Documentation

> Ajoutez un (des) lien(s) vers la documentation si nécessaire

## 📸 Captures d'écran

| Avant | Après |
| ----- | ----- |
|       |       |

## 🔗 Ticket associé

[Asana]()
