### PR TITLE
Converter : Replacement du champ missionId par operationId dans le RC-RI

### DIFF
--- a/converter/converter/cisu/resources_info/resources_info_cisu_constants.py
+++ b/converter/converter/cisu/resources_info/resources_info_cisu_constants.py
@@ -2,6 +2,8 @@ class ResourcesInfoCISUConstants:
     RESOURCE_PATH = "$.resource"
     STATE_PATH = "$.state"
     VEHICLE_TYPE_PATH = "$.vehicleType"
+    MISSION_ID_PATH = "$.missionId"
+    OPERATION_ID_PATH = "$.operationId"
 
     CASE_ID_FIELD = "caseId"
     RESOURCE_ID_KEY = "resourceId"

--- a/converter/converter/cisu/resources_info/resources_info_cisu_converter.py
+++ b/converter/converter/cisu/resources_info/resources_info_cisu_converter.py
@@ -15,7 +15,7 @@ from converter.repositories.message_repository import (
     get_last_rc_ri_by_case_id,
     get_rs_messages_by_case_id,
 )
-from converter.utils import get_field_value, set_value, delete_paths
+from converter.utils import get_field_value, set_value, delete_paths, switch_field_name
 import logging
 
 logger = logging.getLogger(__name__)
@@ -69,6 +69,13 @@ class ResourcesInfoCISUConverter(BaseCISUConverter):
 
             # RS-RI does not carry GPS position — remove it if present
             delete_paths(resource, [ResourcesInfoCISUConstants.POSITION_KEY])
+
+            # Map operationId to missionId
+            switch_field_name(
+                resource,
+                ResourcesInfoCISUConstants.OPERATION_ID_PATH,
+                ResourcesInfoCISUConstants.MISSION_ID_PATH,
+            )
 
         return cls.format_rs_output_json(output_json, output_use_case_json)
 
@@ -317,12 +324,21 @@ class ResourcesInfoCISUConverter(BaseCISUConverter):
                 cls._translate_to_cisu_vehicle_type(resource)
                 cls._keep_last_state(resource)
                 cls._remove_patient_id(resource)
+                cls._replace_operation_id_by_mission_id(resource)
 
                 converted_resources.append(resource)
             except ConversionError:
                 continue
 
         return converted_resources
+
+    @classmethod
+    def _replace_operation_id_by_mission_id(cls, resource):
+        switch_field_name(
+            resource,
+            ResourcesInfoCISUConstants.MISSION_ID_PATH,
+            ResourcesInfoCISUConstants.OPERATION_ID_PATH,
+        )
 
     @classmethod
     def _remove_patient_id(cls, resource):

--- a/converter/tests/fixtures/RC-RI/RC-RI_V3.0_exhaustive_fill.json
+++ b/converter/tests/fixtures/RC-RI/RC-RI_V3.0_exhaustive_fill.json
@@ -38,7 +38,7 @@
         "resourceId": "fr.fire.sis076.cgo-076.resource.VSAV3A",
         "requestId": "fr.fire.sis076.cgo-076.request.177",
         "centerName": "Centre de Secours 76 - A",
-        "missionId": "fr.fire.sis076.cgo-076.mission.177",
+        "operationId": "fr.fire.sis076.cgo-076.mission.177",
         "centerCity": "75011",
         "orgId": "fr.fire.sdis76.cgo-076",
         "name": "VSAV 76 - 22D8",


### PR DESCRIPTION
## 🔎 Détails

- Ajout de la logique dans les 2 sens de ciruclation pour remplacer le champ `operationId` par `missionId` lors de la conversion RC-RI <-> RS-RI

## 📸 Screenshot

<details>
<summary>Sens 15 vers 18 </summary>
<pre>
❯ curl -X POST http://localhost:8083/convert \
     -H "Content-Type: application/json" \
     -d @payload_rs_ri.json
{
  "converted_messages": [
    {
      "content": [
        {
          "jsonContent": {
            "embeddedJsonContent": {
              "message": {
                "kind": "Report",
                "messageId": "fr.health.samuA_2608323d-507d-4cbf-bf74-52007f8124ea",
                "recipient": [
                  {
                    "URI": "hubsante:fr.fire.sdisZ",
                    "name": "sdisZ"
                  }
                ],
                "resourcesInfoCisu": {
                  "caseId": "fr.health.samu440.DRFR154402413800236",
                  "resource": [
                    {
                      "contact": {
                        "details": "0762865426",
                        "type": "TEL"
                      },
                      "datetime": "2024-05-18T18:20:00+02:00",
                      "freetext": [
                        "Eric AZERTY, Marie-Jo ANELI, Pierre LOUITUT"
                      ],
                      "name": "VLM2",
                      "operationId": "DRFR15DDXAAJJJ0000.M001", # <= transformation du champ en operationId
                      "orgId": "fr.health.samu440",
                      ....
</pre>
</details>

<details>
<summary>Sens 18 vers 15</summary>
<pre>
❯ curl -X POST http://localhost:8083/convert \
     -H "Content-Type: application/json" \
     -d @payload_rc_ri.json
{
  "converted_messages": [
    {
      "content": [
        {
          "jsonContent": {
            "embeddedJsonContent": {
              "message": {
                "kind": "Report",
                "messageId": "fr.fire.sdisZ_2608323d-507d-4cbf-bf74-52007f8124ea",
                "recipient": [
                  {
                    "URI": "hubsante:fr.health.samuA",
                    "name": "samuA"
                  }
                ],
                "resourcesInfo": {
                  "caseId": "fr.health.samu440.DRFR154402413800236",
                  "resource": [
                    {
                      "centerCity": "44109",
                      "datetime": "2024-05-18T18:22:00+02:00",
                      "missionId": "DRFR15DDXAAJJJ0000.M001", # <= CHAMP OPERATION_ID TRANSFORMÉ EN MISSION_ID
                      "name": "VLM1",
                      "orgId": "fr.health.samu440",
                      "resourceId": "fr.health.samu440.resource.VLM1",
                      "state": [
                        {
                          "availability": false,
                          "datetime": "2024-05-18T18:10:00+02:00",
                          "status": "DECLENCHE"
                        }
                      ],
                      "team": {
                        "medicalLevel": "MED"
                      },
                      "vehicleType": "SMUR"
                    }
...
</pre>
</details>

## 🔗 Ticket associé

[Asana]()
