### PR TITLE
feat(converter): reduce gunicorn workers to 2

### DIFF
--- a/converter/Dockerfile
+++ b/converter/Dockerfile
@@ -58,4 +58,4 @@ ENV PROMETHEUS_MULTIPROC_DIR=/tmp/prometheus_metrics
 ENV FLASK_ENV=production
 
 # Use Gunicorn for production deployment
-CMD ["uv", "run", "--no-dev", "gunicorn", "-c", "gunicorn.conf.py", "-w", "4", "-b", "0.0.0.0:8080", "converter.converter:app"]
+CMD ["uv", "run", "--no-dev", "gunicorn", "-c", "gunicorn.conf.py", "-w", "2", "-b", "0.0.0.0:8080", "converter.converter:app"]


### PR DESCRIPTION
## 🔎 Détails

Pas besoin de 4 workers comme actuellement, le scaling doit s'effectuer par le biais de kube.
Réduction du nombre de workers gunicorn au niveau du converter. Passage de 4 à 2.

## 📸 Captures d'écran

Avant (4 pid) :
<img width="790" height="212" alt="image" src="https://github.com/user-attachments/assets/2528db78-858c-403a-86bd-ec5b45382068" />

Après (2 pid) : 

<img width="797" height="188" alt="image" src="https://github.com/user-attachments/assets/aa1364d8-f179-459c-bbea-ffd83f469041" />

## 🔗 Ticket associé

[Asana](https://app.asana.com/1/1201445755223134/project/1213900980560885/task/1214402344848912?focus=true)

## Vaildation

dans le dossier converter, lancer le build de l'image : 

```
docker build -t cisu-converter .
```

Après build, lancer l'image : 

```
docker run -p 8080:8080 cisu-converter
```

- [x] Observer 2 pid
