### PR TITLE
refactor(converter): converter route payload typing

### DIFF
--- a/converter/converter/converter.py
+++ b/converter/converter/converter.py
@@ -4,6 +4,8 @@ import os
 from prometheus_flask_exporter.multiprocess import GunicornInternalPrometheusMetrics
 from prometheus_flask_exporter import PrometheusMetrics
 from pymongo import timeout
+from pydantic import BaseModel, ConfigDict, Field, ValidationError
+from typing import Any
 
 from converter.conversion_strategy.conversion_strategy import conversion_strategy
 from converter.utils import (
@@ -31,9 +33,34 @@ else:
 logger = logging.getLogger(__name__)
 
 
+class ConvertRequest(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+    source_version: str = Field(alias="sourceVersion")
+    target_version: str = Field(alias="targetVersion")
+    edxl: dict[str, Any]
+    type: ConversionType
+
+
 def raise_error(message, code: int = 400):
     logger.error(message)
     return jsonify({"error": message}), code
+
+
+def format_validation_error(e):
+    errors = e.errors()
+    missing = [err["loc"][0] for err in errors if err["type"] == "missing"]
+    if missing:
+        return f"Missing required fields: {', '.join(str(f) for f in missing)}"
+
+    extra = [err["loc"][0] for err in errors if err["type"] == "extra_forbidden"]
+    if extra:
+        return f"Unknown fields: {', '.join(str(f) for f in extra)}"
+
+    for err in errors:
+        if err["loc"][0] == "type":
+            return f"Conversion type must be one of {[t.value for t in ConversionType]}"
+
+    return "Invalid request payload"
 
 
 def extract_message_type_from_payload():
@@ -59,20 +86,17 @@ def extract_message_type_from_payload():
 def convert():
     if not request.is_json:
         return raise_error("Content-Type must be application/json")
-
-    req_data = request.get_json()
-    logger.debug(f"Received conversion request: {req_data}")
-    source_version = req_data.get("sourceVersion")
-    target_version = req_data.get("targetVersion")
-    edxl_json = req_data.get("edxl")
-    conversion_type = req_data.get("type")
-
     try:
-        conversion_type = ConversionType(conversion_type)
-    except ValueError:
-        return raise_error(
-            f'Conversion type "{conversion_type}" must be one of {[t.value for t in ConversionType]}'
-        )
+        req_data = ConvertRequest.model_validate(request.get_json())
+    except ValidationError as e:
+        return raise_error(format_validation_error(e))
+
+    logger.debug(f"Received conversion request: {req_data}")
+
+    source_version = req_data.source_version
+    target_version = req_data.target_version
+    edxl_json = req_data.edxl
+    conversion_type = req_data.type
 
     # Store data in request context to be used in logs
     try:
@@ -87,11 +111,6 @@ def convert():
         )
     except Exception:
         pass
-
-    if not source_version or not target_version or not edxl_json:
-        return raise_error(
-            f"Missing required fields: sourceVersion={source_version}, targetVersion={target_version}, edxl present={edxl_json is not None}"
-        )
 
     try:
         converted_messages = conversion_strategy(

--- a/converter/tests/test_converter.py
+++ b/converter/tests/test_converter.py
@@ -43,7 +43,6 @@ def test_convert_cisu_invalid_direction(client):
             "sourceVersion": "v3",
             "targetVersion": "v3",
             "edxl": envelope["edxl"],
-            "cisuConversion": True,
             "type": "CISUTranscoding",
         },
     )
@@ -61,7 +60,6 @@ def test_convert_version_with_invalid_source_version(client):
             "sourceVersion": "v4",
             "targetVersion": "v1",
             "edxl": edxl_json,
-            "cisuConversion": False,
             "type": "HealthVersionConversion",
         },
     )
@@ -80,7 +78,6 @@ def test_convert_version_with_invalid_target_version(client):
             "sourceVersion": "v1",
             "targetVersion": "v4",
             "edxl": edxl_json,
-            "cisuConversion": False,
             "type": "HealthVersionConversion",
         },
     )
@@ -110,7 +107,6 @@ def test_convert_edxl_versions(client, source_version, target_version):
             "sourceVersion": source_version,
             "targetVersion": target_version,
             "edxl": edxl_json,
-            "cisuConversion": False,
             "type": "HealthVersionConversion",
         },
     )
@@ -138,7 +134,6 @@ def test_convert_from_cisu(client, rs_target_version):
             "sourceVersion": CISUConstants.CISU_EXPECTED_MODEL_VERSION,
             "targetVersion": rs_target_version,
             "edxl": edxl_json,
-            "cisuConversion": True,
             "type": "CISUTranscoding",
         },
     )
@@ -174,7 +169,6 @@ def test_convert_to_cisu(client, rs_source_version):
             "sourceVersion": rs_source_version,
             "targetVersion": CISUConstants.CISU_EXPECTED_MODEL_VERSION,
             "edxl": edxl_json,
-            "cisuConversion": True,
             "type": "CISUTranscoding",
         },
     )
@@ -202,7 +196,6 @@ def test_convert_to_cisu_with_invalid_cisu_target_version(client):
             "sourceVersion": "v1",
             "targetVersion": "v2",
             "edxl": edxl_json,
-            "cisuConversion": True,
             "type": "CISUTranscoding",
         },
     )
@@ -221,7 +214,6 @@ def test_convert_to_cisu_with_invalid_cisu_source_version(client):
             "sourceVersion": "v2",
             "targetVersion": "v1",
             "edxl": edxl_json,
-            "cisuConversion": True,
             "type": "CISUTranscoding",
         },
     )

--- a/converter/tests/test_converter.py
+++ b/converter/tests/test_converter.py
@@ -27,6 +27,74 @@ def test_convert_missing_required_fields(client):
     assert "Missing required fields" in response.json["error"]
 
 
+def test_convert_missing_single_field_names_it(client):
+    """Test that missing field name is reported in the error message"""
+    response = client.post(
+        "/convert",
+        json={
+            "sourceVersion": "v1",
+            "targetVersion": "v2",
+            "type": "HealthVersionConversion",
+        },
+    )
+    assert response.status_code == 400
+    assert "Missing required fields" in response.json["error"]
+    assert "edxl" in response.json["error"]
+
+
+def test_convert_extra_forbidden_field(client):
+    """Test sending request with an unknown extra field"""
+    edxl_json = TestHelper.create_edxl_json_from_schema(
+        TestConstants.EDXL_FIRE_TO_HEALTH_ENVELOPE_PATH, TestConstants.RS_EDA_TAG
+    )
+    response = client.post(
+        "/convert",
+        json={
+            "sourceVersion": "v1",
+            "targetVersion": "v2",
+            "edxl": edxl_json,
+            "type": "HealthVersionConversion",
+            "unexpected": "boom",
+        },
+    )
+    assert response.status_code == 400
+    assert "Unknown fields" in response.json["error"]
+    assert "unexpected" in response.json["error"]
+
+
+def test_convert_invalid_type_enum(client):
+    """Test sending request with an invalid conversion type"""
+    edxl_json = TestHelper.create_edxl_json_from_schema(
+        TestConstants.EDXL_FIRE_TO_HEALTH_ENVELOPE_PATH, TestConstants.RS_EDA_TAG
+    )
+    response = client.post(
+        "/convert",
+        json={
+            "sourceVersion": "v1",
+            "targetVersion": "v2",
+            "edxl": edxl_json,
+            "type": "NotARealType",
+        },
+    )
+    assert response.status_code == 400
+    assert "Conversion type must be one of" in response.json["error"]
+
+
+def test_convert_invalid_edxl_shape(client):
+    """Test sending request with edxl as a non-dict value"""
+    response = client.post(
+        "/convert",
+        json={
+            "sourceVersion": "v1",
+            "targetVersion": "v2",
+            "edxl": "not a dict",
+            "type": "HealthVersionConversion",
+        },
+    )
+    assert response.status_code == 400
+    assert response.json["error"] == "Invalid request payload"
+
+
 def test_convert_cisu_invalid_direction(client):
     """Test sending request with both sender and recipient as health"""
     # Load base envelope


### PR DESCRIPTION
## 🔎 Détails

Dans le converter, le body de la requête à la méthode POST /convert est validé à la main ce qui est fastidieux et error prone.

Dans cette PR :

- création d'une classe `ConvertRequest` pour typer le payload
- création d'une fonction `format_validation_error` qui prend en params un résultat d'erreur de parsing pydantic et retourne un message associé
- suppression du paramètre déprécié `cisuConversion`
-  ajout de tests pour couvrir les requêtes malformées

## Captures d'écran

<img width="781" height="179" alt="image" src="https://github.com/user-attachments/assets/142369d7-29db-443e-99d9-a5651fab29f2" />
<img width="763" height="186" alt="image" src="https://github.com/user-attachments/assets/f0d34293-cea5-4672-9e59-e7391a5d3d7b" />
<img width="757" height="182" alt="image" src="https://github.com/user-attachments/assets/28d4fad4-369c-4405-8295-e61427ffedce" />
<img width="734" height="168" alt="image" src="https://github.com/user-attachments/assets/e30f5c67-8e7d-415d-a693-8064bd6bf766" />
<img width="817" height="157" alt="image" src="https://github.com/user-attachments/assets/ba173b67-bb14-4261-abd6-783b271f7812" />
<img width="765" height="186" alt="image" src="https://github.com/user-attachments/assets/233305a6-fc83-40ac-a91f-802c5c1a91b0" />
<img width="739" height="158" alt="image" src="https://github.com/user-attachments/assets/7fda3edd-f786-4c8b-8bdb-59da6aa0edd3" />

## 🔗 Ticket associé

[Asana](https://app.asana.com/1/1201445755223134/project/1214061829169745/task/1214971810401606?focus=true)
