### PR TITLE
feat(converter): cisu version conversion strategy (v3 <-> vactive)

### DIFF
--- a/converter/converter/cisu_version_converters/base_cisu_version_converter.py
+++ b/converter/converter/cisu_version_converters/base_cisu_version_converter.py
@@ -1,0 +1,45 @@
+from typing import Any, Dict
+
+from converter.conversion_mixin import ConversionMixin
+from converter.cisu_transcoders.constants import CISUConstants
+
+
+class BaseCISUVersionConverter(ConversionMixin):
+    def __init__(self):
+        raise ValueError(
+            "BaseCISUVersionConverter is an abstract class and cannot be instantiated directly. Use a subclass instead."
+        )
+
+    @classmethod
+    def convert_v3_to_vactive(cls, edxl_json: Dict[str, Any]) -> Dict[str, Any]:
+        raise NotImplementedError("convert_v3_to_vactive not implemented yet.")
+
+    @classmethod
+    def convert_vactive_to_v3(cls, edxl_json: Dict[str, Any]) -> Dict[str, Any]:
+        raise NotImplementedError("convert_vactive_to_v3 not implemented yet.")
+
+    @classmethod
+    def get_message_type(cls) -> str:
+        raise NotImplementedError(
+            "Subclasses must implement this method to return the message type in RS specifications."
+        )
+
+    @classmethod
+    def convert(
+        cls, source_version: str, target_version: str, edxl_json: Dict[str, Any]
+    ):
+        if (
+            source_version == CISUConstants.CISU_EXPECTED_MODEL_VERSION
+            and target_version
+            == CISUConstants.HEALTH_EXPECTED_VERSION_FOR_CISU_CONVERSION
+        ):
+            return cls.convert_vactive_to_v3(edxl_json)
+        elif (
+            source_version == CISUConstants.HEALTH_EXPECTED_VERSION_FOR_CISU_CONVERSION
+            and target_version == CISUConstants.CISU_EXPECTED_MODEL_VERSION
+        ):
+            return cls.convert_v3_to_vactive(edxl_json)
+        else:
+            raise ValueError(
+                f"CISU version conversion from '{source_version}' to '{target_version}' for message type '{cls.get_message_type()}' is currently not implemented."
+            )

--- a/converter/converter/cisu_version_converters/create_case/rc_eda_version_converter.py
+++ b/converter/converter/cisu_version_converters/create_case/rc_eda_version_converter.py
@@ -1,0 +1,9 @@
+from converter.cisu_version_converters.identical_cisu_version_converter import (
+    IdenticalCISUVersionConverter,
+)
+
+
+class CreateCaseVersionConverter(IdenticalCISUVersionConverter):
+    @classmethod
+    def get_message_type(cls) -> str:
+        return "createCase"

--- a/converter/converter/cisu_version_converters/identical_cisu_version_converter.py
+++ b/converter/converter/cisu_version_converters/identical_cisu_version_converter.py
@@ -1,0 +1,15 @@
+from typing import Dict, Any
+
+from converter.cisu_version_converters.base_cisu_version_converter import (
+    BaseCISUVersionConverter,
+)
+
+
+class IdenticalCISUVersionConverter(BaseCISUVersionConverter):
+    @classmethod
+    def convert_v3_to_vactive(cls, edxl_json) -> Dict[str, Any]:
+        return edxl_json
+
+    @classmethod
+    def convert_vactive_to_v3(cls, edxl_json: Dict[str, Any]) -> Dict[str, Any]:
+        return edxl_json

--- a/converter/converter/cisu_version_converters/resources_info_cisu/resources_info_cisu_version_converter.py
+++ b/converter/converter/cisu_version_converters/resources_info_cisu/resources_info_cisu_version_converter.py
@@ -1,0 +1,9 @@
+from converter.cisu_version_converters.identical_cisu_version_converter import (
+    IdenticalCISUVersionConverter,
+)
+
+
+class ResourcesInfoCISUVersionConverter(IdenticalCISUVersionConverter):
+    @classmethod
+    def get_message_type(cls) -> str:
+        return "resourcesInfoCisu"

--- a/converter/converter/conversion_strategy/cisu_version_conversion_strategy.py
+++ b/converter/converter/conversion_strategy/cisu_version_conversion_strategy.py
@@ -1,4 +1,17 @@
 import logging
+from converter.cisu_version_converters.create_case.rc_eda_version_converter import (
+    CreateCaseVersionConverter,
+)
+from converter.cisu_version_converters.resources_info_cisu.resources_info_cisu_version_converter import (
+    ResourcesInfoCISUVersionConverter,
+)
+from converter.utils import (
+    extract_message_type_from_message_content,
+    extract_message_content,
+)
+from converter.cisu_version_converters.identical_cisu_version_converter import (
+    IdenticalCISUVersionConverter,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -6,6 +19,25 @@ logger = logging.getLogger(__name__)
 def cisu_version_conversion_strategy(edxl_json, source_version, target_version):
     logger.info(f"CISU Conversion initiated from {source_version} to {target_version}")
 
-    raise NotImplementedError(
-        "Conversion strategy 'cisu_version_conversion_strategy' not yet implemented."
-    )
+    message_content = extract_message_content(edxl_json)
+    selected_strategy = select_conversion_strategy(message_content)
+
+    return selected_strategy.convert(source_version, target_version, edxl_json)
+
+
+def select_conversion_strategy(message_content):
+    if "createCase" in message_content:
+        return CreateCaseVersionConverter
+    elif "resourcesInfoCisu" in message_content:
+        return ResourcesInfoCISUVersionConverter
+    elif "reference" in message_content:
+        return IdenticalCISUVersionConverter
+    elif "error" in message_content:
+        return IdenticalCISUVersionConverter
+    else:
+        deducted_message_type = extract_message_type_from_message_content(
+            message_content
+        )
+        raise ValueError(
+            f"CISU Version conversion for message type '{deducted_message_type}' is not implemented."
+        )

--- a/converter/tests/cisu_version/test_create_case_version_converter.py
+++ b/converter/tests/cisu_version/test_create_case_version_converter.py
@@ -1,0 +1,35 @@
+import unittest
+
+from converter.cisu_version_converters.create_case.rc_eda_version_converter import (
+    CreateCaseVersionConverter,
+)
+from tests.constants import TestConstants
+from tests.test_helpers import TestHelper
+
+
+class TestCreateCaseVersionConverter(unittest.TestCase):
+    def setUp(self):
+        self.edxl_envelope_health_to_fire_path = (
+            TestConstants.EDXL_HEALTH_TO_FIRE_ENVELOPE_PATH
+        )
+        self.edxl_envelope_fire_to_health_path = (
+            TestConstants.EDXL_FIRE_TO_HEALTH_ENVELOPE_PATH
+        )
+        self.fixtures_folder_path = "tests/fixtures/"
+        self.converter = CreateCaseVersionConverter
+
+    def test_v3_to_vactive(self):
+        message = TestHelper.create_edxl_json_from_sample(
+            self.edxl_envelope_health_to_fire_path,
+            self.fixtures_folder_path + "RC-EDA/RC-EDA_exhaustive_fill.json",
+        )
+        converted_message = self.converter.convert_v3_to_vactive(message)
+        assert converted_message == message
+
+    def test_vactive_to_v3(self):
+        message = TestHelper.create_edxl_json_from_sample(
+            self.edxl_envelope_fire_to_health_path,
+            self.fixtures_folder_path + "RC-EDA/RC-EDA_exhaustive_fill.json",
+        )
+        converted_message = self.converter.convert_vactive_to_v3(message)
+        assert converted_message == message

--- a/converter/tests/cisu_version/test_resource_info_cisu_version_converter.py
+++ b/converter/tests/cisu_version/test_resource_info_cisu_version_converter.py
@@ -1,0 +1,35 @@
+import unittest
+
+from converter.cisu_version_converters.resources_info_cisu.resources_info_cisu_version_converter import (
+    ResourcesInfoCISUVersionConverter,
+)
+from tests.constants import TestConstants
+from tests.test_helpers import TestHelper
+
+
+class TestResourceInfoCisuVersionConverter(unittest.TestCase):
+    def setUp(self):
+        self.edxl_envelope_health_to_fire_path = (
+            TestConstants.EDXL_HEALTH_TO_FIRE_ENVELOPE_PATH
+        )
+        self.edxl_envelope_fire_to_health_path = (
+            TestConstants.EDXL_FIRE_TO_HEALTH_ENVELOPE_PATH
+        )
+        self.fixtures_folder_path = "tests/fixtures/"
+        self.converter = ResourcesInfoCISUVersionConverter
+
+    def test_v3_to_vactive(self):
+        message = TestHelper.create_edxl_json_from_sample(
+            self.edxl_envelope_health_to_fire_path,
+            self.fixtures_folder_path + "RC-RI/RC-RI_V3.0_exhaustive_fill.json",
+        )
+        converted_message = self.converter.convert_v3_to_vactive(message)
+        assert converted_message == message
+
+    def test_vactive_to_v3(self):
+        message = TestHelper.create_edxl_json_from_sample(
+            self.edxl_envelope_fire_to_health_path,
+            self.fixtures_folder_path + "RC-RI/RC-RI_V3.0_exhaustive_fill.json",
+        )
+        converted_message = self.converter.convert_vactive_to_v3(message)
+        assert converted_message == message

--- a/converter/tests/conversion_strategy/test_cisu_version_conversion_strategy.py
+++ b/converter/tests/conversion_strategy/test_cisu_version_conversion_strategy.py
@@ -1,0 +1,87 @@
+import unittest
+from unittest.mock import patch, ANY
+
+from converter.cisu_transcoders.constants import CISUConstants
+from converter.conversion_strategy.cisu_version_conversion_strategy import (
+    cisu_version_conversion_strategy,
+)
+from tests.constants import TestConstants
+from tests.test_helpers import TestHelper
+
+V3 = CISUConstants.HEALTH_EXPECTED_VERSION_FOR_CISU_CONVERSION
+VACTIVE = CISUConstants.CISU_EXPECTED_MODEL_VERSION
+
+
+class TestCisuVersionConversionStrategy(unittest.TestCase):
+    @staticmethod
+    def run_v3_to_vactive_cisu_version_conversion_strategy(message_type: str) -> None:
+        message_json_path = TestHelper.get_json_files(message_type)[0]["path"]
+        edxl_json = TestHelper.create_edxl_json_from_sample(
+            TestConstants.EDXL_HEALTH_TO_FIRE_ENVELOPE_PATH, message_json_path
+        )
+        cisu_version_conversion_strategy(edxl_json, V3, VACTIVE)
+
+    @staticmethod
+    def run_vactive_to_v3_cisu_version_conversion_strategy(message_type: str) -> None:
+        message_json_path = TestHelper.get_json_files(message_type)[0]["path"]
+        edxl_json = TestHelper.create_edxl_json_from_sample(
+            TestConstants.EDXL_FIRE_TO_HEALTH_ENVELOPE_PATH, message_json_path
+        )
+        cisu_version_conversion_strategy(edxl_json, VACTIVE, V3)
+
+    def test_cisu_version_conversion_strategy_raise_error_when_converting_unsupported_message_type(
+        self,
+    ):
+        edxl_json = {
+            "content": [
+                {
+                    "jsonContent": {
+                        "embeddedJsonContent": {
+                            "message": {"notSupportedMessageType": {}}
+                        }
+                    }
+                }
+            ],
+            "senderID": "senderId",
+            "descriptor": {"explicitAddress": {"explicitAddressValue": "recipientId"}},
+        }
+
+        with self.assertRaisesRegex(
+            ValueError,
+            "Perimeter translation for message type 'notSupportedMessageType' is not implemented.",
+        ):
+            cisu_version_conversion_strategy(edxl_json, V3, VACTIVE)
+
+    @patch(
+        "converter.conversion_strategy.cisu_version_conversion_strategy.CreateCaseVersionConverter.convert"
+    )
+    def test_create_case_v3_to_vactive(self, mock_convert):
+        self.run_v3_to_vactive_cisu_version_conversion_strategy(
+            TestConstants.RC_EDA_TAG
+        )
+
+        mock_convert.assert_called_once_with(V3, VACTIVE, ANY)
+
+    @patch(
+        "converter.conversion_strategy.cisu_version_conversion_strategy.CreateCaseVersionConverter.convert"
+    )
+    def test_create_case_vactive_to_v3(self, mock_convert):
+        self.run_vactive_to_v3_cisu_version_conversion_strategy(
+            TestConstants.RC_EDA_TAG
+        )
+
+        mock_convert.assert_called_once_with(VACTIVE, V3, ANY)
+
+    @patch(
+        "converter.conversion_strategy.cisu_version_conversion_strategy.ResourcesInfoCISUVersionConverter.convert"
+    )
+    def test_resources_info_cisu_v3_to_vactive(self, mock_convert):
+        self.run_v3_to_vactive_cisu_version_conversion_strategy(TestConstants.RC_RI_TAG)
+        mock_convert.assert_called_once_with(V3, VACTIVE, ANY)
+
+    @patch(
+        "converter.conversion_strategy.cisu_version_conversion_strategy.ResourcesInfoCISUVersionConverter.convert"
+    )
+    def test_resources_info_cisu_vactive_to_v3(self, mock_convert):
+        self.run_vactive_to_v3_cisu_version_conversion_strategy(TestConstants.RC_RI_TAG)
+        mock_convert.assert_called_once_with(VACTIVE, V3, ANY)

--- a/converter/tests/conversion_strategy/test_cisu_version_conversion_strategy.py
+++ b/converter/tests/conversion_strategy/test_cisu_version_conversion_strategy.py
@@ -48,7 +48,7 @@ class TestCisuVersionConversionStrategy(unittest.TestCase):
 
         with self.assertRaisesRegex(
             ValueError,
-            "Perimeter translation for message type 'notSupportedMessageType' is not implemented.",
+            "CISU Version conversion for message type 'notSupportedMessageType' is not implemented.",
         ):
             cisu_version_conversion_strategy(edxl_json, V3, VACTIVE)
 

--- a/converter/tests/conversion_strategy/test_conversion_strategy.py
+++ b/converter/tests/conversion_strategy/test_conversion_strategy.py
@@ -1,6 +1,5 @@
 import unittest
 from unittest.mock import patch
-import pytest
 from converter.conversion_strategy.conversion_strategy import conversion_strategy
 from converter.constants import ConversionType
 
@@ -39,22 +38,6 @@ class TestConversionStrategy(unittest.TestCase):
         mock_health_version_conversion_strategy.assert_called_once_with(
             edxl_json, source_version, target_version
         )
-
-    def test_conversion_strategy_with_cisu_version_conversion_raises_not_implemented(
-        self,
-    ):
-        edxl_json = {}
-        source_version = "source_version"
-        target_version = "target_version"
-        conversion_type = ConversionType.CISUVersionConversion
-
-        with pytest.raises(
-            NotImplementedError,
-            match="Conversion strategy 'cisu_version_conversion_strategy' not yet implemented.",
-        ):
-            conversion_strategy(
-                edxl_json, source_version, target_version, conversion_type
-            )
 
     @patch(
         "converter.conversion_strategy.conversion_strategy.health_version_conversion_strategy"


### PR DESCRIPTION
## 🔎 Détails

Actuellement, le flux de conversion de version 15-nexsis renvoie une erreur dans tous les cas.
On souhaite pouvoir convertir les messages RC-EDA et RC-RI de la v3 à la vactive.
Du point de vue métier, il n'y a pas de changement à effectuer pour ces message dans le flux.

- création d'une `base_cisu_version_converter`
- création d'un `IdenticalCisuVersionConverter` qui renvoie exactement le JSON en entrée
- création d'un convertisseur pour le RC-EDA qui étend le `IdenticalCisuVersionConverter`
- création d'un convertisseur pour le RC-RI qui étend le `IdenticalCisuVersionConverter`
- mise à jour de la stratégie de conversion de version pour le CISU, en `wirant` cisu_version_conversion_strategy dans `conversion_strategy`

## ✅ Validation

Pré-requis : setup local-dev en cours d'exécution (cf. [lancer le setup local](https://github.com/ansforge/SAMU-Hub-Config/blob/main/tools/local-dev/README.md)).

Toutes les commandes s'exécutent depuis la racine `converter/`.

<details>
<summary><strong>Étape 1 — Préparer payload <code>createCase</code> (RC-EDA)</strong></summary>

```bash
export EDXL=$(jq -n \
  --slurpfile env tests/fixtures/EDXL/edxl_envelope_fire_to_health.json \
  --slurpfile msg tests/fixtures/RC-EDA/RC-EDA_required_fields.json \
  '($env[0].edxl | .content[0].jsonContent.embeddedJsonContent.message += $msg[0])')
```

</details>

<details>
<summary><strong>Étape 2 — <code>createCase</code> v3 → vactive</strong></summary>

```bash
curl -s -X POST http://localhost:8083/convert \
  -H "Content-Type: application/json" \
  -d "$(jq -n --argjson edxl "$EDXL" \
    '{sourceVersion:"v3", targetVersion:"vactive", type:"CISUVersionConversion", edxl:$edxl}')" \
  > res.json

diff --color=always -u \
  <(jq -S '.content[0]' <<< "$EDXL") \
  <(jq -S '.converted_messages[0].content[0]' res.json)
```
-> ✅ retour vide, pas de diff.

</details>

<details>
<summary><strong>Étape 3 — <code>createCase</code> vactive → v3</strong></summary>

```bash
curl -X POST http://localhost:8083/convert \
  -H "Content-Type: application/json" \
  -d "$(jq -n --argjson edxl "$EDXL" \
    '{sourceVersion:"vactive", targetVersion:"v3", type:"CISUVersionConversion", edxl:$edxl}')" > res.json

diff --color=always -u \
  <(jq -S '.content[0]' <<< "$EDXL") \
  <(jq -S '.converted_messages[0].content[0]' res.json)
```
-> ✅ retour vide, pas de diff.

</details>

<details>
<summary><strong>Étape 4 — Préparer payload <code>resourcesInfoCisu</code> (RC-RI)</strong></summary>

```bash
export EDXL=$(jq -n \
  --slurpfile env tests/fixtures/EDXL/edxl_envelope_fire_to_health.json \
  --slurpfile msg tests/fixtures/RC-RI/RC-RI_V3.0_exhaustive_fill.json \
  '($env[0].edxl | .content[0].jsonContent.embeddedJsonContent.message += $msg[0])')
```

</details>

<details>
<summary><strong>Étape 5 — <code>resourcesInfoCisu</code> v3 → vactive</strong></summary>

```bash
curl -X POST http://localhost:8083/convert \
  -H "Content-Type: application/json" \
  -d "$(jq -n --argjson edxl "$EDXL" \
    '{sourceVersion:"v3", targetVersion:"vactive", type:"CISUVersionConversion", edxl:$edxl}')" > res.json

diff --color=always -u \
  <(jq -S '.content[0]' <<< "$EDXL") \
  <(jq -S '.converted_messages[0].content[0]' res.json)
```

-> ✅ retour vide, pas de diff.

</details>

<details>
<summary><strong>Étape 6 — <code>resourcesInfoCisu</code> vactive → v3</strong></summary>

```bash
curl -X POST http://localhost:8083/convert \
  -H "Content-Type: application/json" \
  -d "$(jq -n --argjson edxl "$EDXL" \
    '{sourceVersion:"vactive", targetVersion:"v3", type:"CISUVersionConversion", edxl:$edxl}')" > res.json

diff --color=always -u \                    
  <(jq -S '.content[0]' <<< "$EDXL") \ 
  <(jq -S '.converted_messages[0].content[0]' res.json)
```

-> ✅ retour vide, pas de diff.

</details>

<details>
<summary><strong>Étape 7 — Cas erreur : message type non supporté (HTTP 400 attendu)</strong></summary>

```bash
export EDXL=$(jq -n \
  --slurpfile env tests/fixtures/EDXL/edxl_envelope_fire_to_health.json \
  '($env[0].edxl | .content[0].jsonContent.embeddedJsonContent.message = {notSupportedMessageType:{}})')

curl -X POST http://localhost:8083/convert \
  -H "Content-Type: application/json" \
  -d "$(jq -n --argjson edxl "$EDXL" \
    '{sourceVersion:"v3", targetVersion:"vactive", type:"CISUVersionConversion", edxl:$edxl}')"
```

Résultat (HTTP 400) :

```json
{
  "error": "Perimeter translation for message type 'notSupportedMessageType' is not implemented."
}
```

</details>


## 🔗 Ticket associé

[Asana](https://app.asana.com/1/1201445755223134/project/1214061829169745/task/1214785982716196?focus=true)
