### PR TITLE
feat(converter): helper script

### DIFF
--- a/converter/README.md
+++ b/converter/README.md
@@ -100,3 +100,43 @@ curl -X POST http://localhost:8080/convert \
   -H "Content-Type: application/json" \
   -d "$(jq --argjson usecase "$(cat ../src/main/resources/sample/examples/RS-EDA/RS-EDA-SMUR_FemmeEnceinte_DelphineVigneau.01.json)" '.sourceVersion = "v3" | .targetVersion = "v3" | .cisuConversion = true | .edxl.content[0].jsonContent.embeddedJsonContent.message |= (. + $usecase)' tests/fixtures/EDXL/edxl_envelope_health_to_fire.json)"
 ```
+
+### Helper script — `scripts/call_convert.sh`
+
+Executable helper to call `/convert` quickly without building the payload by hand.
+
+**Prerequisite**: local-dev setup running (see [launch local dev setup](https://github.com/ansforge/SAMU-Hub-Config/blob/main/tools/local-dev/README.md)).
+
+Usage:
+
+```bash
+scripts/call_convert.sh <sourceVersion> <targetVersion> <type> <useCase> [options]
+```
+
+Positional args:
+- `sourceVersion`, `targetVersion`: `v1` | `v2` | `v3` | `vactive`
+- `type`: `HealthVersionConversion` | `CISUTranscoding` | `CISUVersionConversion` (see `ConversionType` in `converter/constants.py`)
+- `useCase`: local path to a JSON file **or** `http(s)://` URL of the message payload
+
+Options:
+- `--envelope <path|url>`: EDXL envelope file or URL (default: `tests/fixtures/EDXL/edxl_envelope_health_to_health.json`)
+- `--converter_url <url>`: converter base URL, `/convert` is appended (default: `http://localhost:8083`)
+- `-h`, `--help`: show usage
+
+Examples:
+
+```bash
+# Local fixture, default envelope (health-to-health)
+scripts/call_convert.sh v3 v2 HealthVersionConversion tests/fixtures/RS-RI/RS-RI_V3.0_exhaustive_fill.json
+
+# CISU transcoding with a custom envelope
+scripts/call_convert.sh v3 vactive CISUTranscoding ./tests/fixtures/RC-EDA/RC-EDA_required_fields.json \
+  --envelope tests/fixtures/EDXL/edxl_envelope_fire_to_health.json
+
+# Remote payload via URL
+scripts/call_convert.sh v3 vactive CISUTranscoding https://raw.githubusercontent.com/org/repo/main/sample.json
+
+# Override endpoint (e.g. staging)
+scripts/call_convert.sh v3 vactive CISUTranscoding ./sample.json \
+  --converter_url https://staging.example.com
+```

--- a/converter/scripts/call_convert.sh
+++ b/converter/scripts/call_convert.sh
@@ -1,0 +1,109 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR=$(cd "$(dirname "$0")" && pwd)
+ENVELOPE_DEFAULT="$SCRIPT_DIR/../tests/fixtures/EDXL/edxl_envelope_health_to_health.json"
+CONVERTER_URL_DEFAULT="http://localhost:8083"
+
+usage() {
+  cat >&2 <<EOF
+Usage: $(basename "$0") <sourceVersion> <targetVersion> <type> <useCase> [options]
+
+Positional arguments:
+  sourceVersion    e.g. v1, v2, v3, vactive (passed as-is)
+  targetVersion    e.g. v1, v2, v3, vactive (passed as-is)
+  type             HealthVersionConversion | CISUTranscoding | CISUVersionConversion
+  useCase          path to a JSON file OR http(s) URL of the message payload
+
+Options:
+  --envelope <path|url>     EDXL envelope file or URL
+                            (default: tests/fixtures/EDXL/edxl_envelope_health_to_health.json)
+  --converter_url <url>     Converter base URL (default: http://localhost:8083)
+  -h, --help                Show this message
+
+Example:
+  $(basename "$0") v3 v2 HealthVersionConversion tests/fixtures/RS-RI/RS-RI_V3.0_exhaustive_fill.json
+EOF
+}
+
+ENVELOPE="$ENVELOPE_DEFAULT"
+CONVERTER_URL="$CONVERTER_URL_DEFAULT"
+POSITIONAL=()
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --envelope)
+      [[ $# -ge 2 ]] || { echo "Error: --envelope requires a value" >&2; usage; exit 1; }
+      ENVELOPE="$2"; shift 2;;
+    --converter_url)
+      [[ $# -ge 2 ]] || { echo "Error: --converter_url requires a value" >&2; usage; exit 1; }
+      CONVERTER_URL="$2"; shift 2;;
+    -h|--help)
+      usage; exit 0;;
+    --*)
+      echo "Error: unknown flag: $1" >&2; usage; exit 1;;
+    *)
+      POSITIONAL+=("$1"); shift;;
+  esac
+done
+
+if [[ ${#POSITIONAL[@]} -ne 4 ]]; then
+  echo "Error: expected 4 positional arguments, got ${#POSITIONAL[@]}" >&2
+  usage
+  exit 1
+fi
+
+SOURCE_VERSION="${POSITIONAL[0]}"
+TARGET_VERSION="${POSITIONAL[1]}"
+TYPE="${POSITIONAL[2]}"
+USECASE="${POSITIONAL[3]}"
+
+for dep in jq curl; do
+  if ! command -v "$dep" >/dev/null 2>&1; then
+    echo "Error: missing required dependency: $dep" >&2
+    exit 1
+  fi
+done
+
+read_source() {
+  local src="$1"
+  local label="$2"
+  if [[ "$src" =~ ^https?:// ]]; then
+    if ! curl -fsSL "$src"; then
+      echo "Error: failed to download $label from $src" >&2
+      return 1
+    fi
+  else
+    if [[ ! -f "$src" ]]; then
+      echo "Error: $label file not found: $src" >&2
+      return 1
+    fi
+    cat "$src"
+  fi
+}
+
+ENVELOPE_JSON=$(read_source "$ENVELOPE" "envelope") || exit 1
+USECASE_JSON=$(read_source "$USECASE" "useCase") || exit 1
+
+PAYLOAD=$(jq -n \
+  --argjson envelope "$ENVELOPE_JSON" \
+  --argjson usecase "$USECASE_JSON" \
+  --arg sourceVersion "$SOURCE_VERSION" \
+  --arg targetVersion "$TARGET_VERSION" \
+  --arg type "$TYPE" \
+  '{
+    sourceVersion: $sourceVersion,
+    targetVersion: $targetVersion,
+    type: $type,
+    edxl: ($envelope.edxl | .content[0].jsonContent.embeddedJsonContent.message |= (. + $usecase))
+  }')
+
+RESPONSE=$(curl -sS -X POST "$CONVERTER_URL/convert" \
+  -H "Content-Type: application/json" \
+  -d "$PAYLOAD")
+
+if printf '%s' "$RESPONSE" | jq . >/dev/null 2>&1; then
+  printf '%s' "$RESPONSE" | jq .
+else
+  printf '%s\n' "$RESPONSE"
+fi


### PR DESCRIPTION
## 🔎 Détails

Petit script bash pour pouvoir tester le converter sur le setup local. 

## 📄 Documentation

(documentation que l'on peut retrouver [ici](https://github.com/ansforge/SAMU-Hub-Modeles/tree/main/converter))

Executable helper to call `/convert` quickly without building the payload by hand.

**Prerequisite**: local-dev setup running (see [launch local dev setup](https://github.com/ansforge/SAMU-Hub-Config/blob/main/tools/local-dev/README.md)).

Usage:

```bash
scripts/call_convert.sh <sourceVersion> <targetVersion> <type> <useCase> [options]
```

Positional args:
- `sourceVersion`, `targetVersion`: `v1` | `v2` | `v3` | `vactive`
- `type`: `HealthVersionConversion` | `CISUTranscoding` | `CISUVersionConversion` (see `ConversionType` in `converter/constants.py`)
- `useCase`: local path to a JSON file **or** `http(s)://` URL of the message payload

Options:
- `--envelope <path|url>`: EDXL envelope file or URL (default: `tests/fixtures/EDXL/edxl_envelope_health_to_health.json`)
- `--converter_url <url>`: converter base URL, `/convert` is appended (default: `http://localhost:8083`)
- `-h`, `--help`: show usage

Examples:

```bash
# Local fixture, default envelope (health-to-health)
scripts/call_convert.sh v3 v2 HealthVersionConversion tests/fixtures/RS-RI/RS-RI_V3.0_exhaustive_fill.json

# CISU transcoding with a custom envelope
scripts/call_convert.sh v3 vactive CISUTranscoding ./tests/fixtures/RC-EDA/RC-EDA_required_fields.json \
  --envelope tests/fixtures/EDXL/edxl_envelope_fire_to_health.json

# Remote payload via URL
scripts/call_convert.sh v3 vactive CISUTranscoding https://raw.githubusercontent.com/org/repo/main/sample.json

# Override endpoint (e.g. staging)
scripts/call_convert.sh v3 vactive CISUTranscoding ./sample.json \
  --converter_url https://staging.example.com
```