### PR TITLE
chore(converter): use writable directory for prometheus metrics

### DIFF
--- a/converter/Dockerfile
+++ b/converter/Dockerfile
@@ -19,10 +19,6 @@ RUN --mount=type=cache,target=/root/.cache/uv \
     --mount=type=bind,source=pyproject.toml,target=pyproject.toml \
     uv sync --frozen --no-dev --no-install-project
 
-# Create metrics directory during first stage because mkdir
-# is not available in non dev base image
-RUN mkdir -p /prometheus_metrics
-
 # Runtime stage: minimal DHI image with no shell or package manager,
 # already runs as the nonroot user.
 FROM dhi.io/python:3.14-alpine3.23
@@ -46,8 +42,7 @@ EXPOSE 8080
 ENV FLASK_ENV=production
 ENV CONVERTER_VERSION=${CONVERTER_VERSION}
 
-# Flask Prometheus Exporter setup
-COPY --from=builder --chown=nonroot:nonroot /prometheus_metrics /tmp/prometheus_metrics
+# Flask Prometheus Exporter setup.
 ENV PROMETHEUS_MULTIPROC_DIR=/tmp/prometheus_metrics
 
 # Use Gunicorn for production deployment

--- a/converter/converter/converter.py
+++ b/converter/converter/converter.py
@@ -20,9 +20,9 @@ configure_logging()
 app = Flask(__name__)
 init_db(app)
 
-is_prod = os.getenv("FLASK_ENV") == "production"
-
-if is_prod:
+multiproc_dir = os.getenv("PROMETHEUS_MULTIPROC_DIR")
+if multiproc_dir:
+    os.makedirs(multiproc_dir, exist_ok=True)
     metrics = GunicornInternalPrometheusMetrics(app)
 else:
     metrics = PrometheusMetrics(app)


### PR DESCRIPTION
## 🔎 Détails

Après le passage à l'image de base Python DHI, découverte d'une bug sur le converter qui ne peut pas démarrer à cause d'un problème de permission sur `/tmp/prometheus_metrics`.

Fix : création du dossier non pas via le Dockefile (problème de potentielles inconsistences de l'utilisateur nonroot mis à disposition par l'image) mais via une commande Python à l'init de l'application.

## ☑️ Validation

Sur intégration :

<img width="304" height="158" alt="Capture d’écran 2026-06-01 à 16 17 22" src="https://github.com/user-attachments/assets/b447da7e-2cd9-4be7-90cd-e9475e3ec25a" />

```
[2026-06-01 13:43:40 +0000] [1] [INFO] Starting gunicorn 26.0.0
[2026-06-01 13:43:40 +0000] [1] [INFO] Listening at: http://0.0.0.0:8080 (1)
[2026-06-01 13:43:40 +0000] [1] [INFO] Using worker: sync
[2026-06-01 13:43:40 +0000] [7] [INFO] Booting worker with pid: 7
[2026-06-01 13:43:40 +0000] [8] [INFO] Booting worker with pid: 8
```