### PR TITLE
Converter: VECTEUR_SAMU conversion handling

### DIFF
--- a/converter/converter/cisu/resources_info/resources_info_cisu_constants.py
+++ b/converter/converter/cisu/resources_info/resources_info_cisu_constants.py
@@ -11,4 +11,4 @@ class ResourcesInfoCISUConstants:
     POSITION_KEY = "position"
 
     VEHICLE_TYPE_SIS = "SIS"
-    VEHICLE_TYPE_SMUR = "SMUR"
+    VEHICLE_TYPE_VECTEUR_SANTE = "VECTEUR_SANTE"

--- a/converter/converter/cisu/resources_info/resources_info_cisu_converter.py
+++ b/converter/converter/cisu/resources_info/resources_info_cisu_converter.py
@@ -346,33 +346,31 @@ class ResourcesInfoCISUConverter(BaseCISUConverter):
 
     @classmethod
     def _translate_to_cisu_vehicle_type(cls, resource: Dict[str, Any]) -> None:
-        """Translate a RS vehicle type to its CISU equivalent, or None if not mappable."""
+        """Translate a RS vehicle type to its CISU equivalent. Throws an error if no vehicleType is provided."""
 
         vehicle_type = get_field_value(
             resource, ResourcesInfoCISUConstants.VEHICLE_TYPE_PATH
         )
+        resourceId = get_field_value(
+            resource, ResourcesInfoCISUConstants.RESOURCE_ID_KEY
+        )
 
         if vehicle_type is None:
             raise ConversionError(
-                f"No vehicle found in RS resource for resource: {resource.get('resourceId')}."
+                f"No vehicle found in RS resource for resource: {resourceId}."
             )
 
-        if vehicle_type.startswith(ResourcesInfoCISUConstants.VEHICLE_TYPE_SIS):
-            set_value(
-                resource,
-                ResourcesInfoCISUConstants.VEHICLE_TYPE_PATH,
-                ResourcesInfoCISUConstants.VEHICLE_TYPE_SIS,
-            )
-        elif vehicle_type.startswith(ResourcesInfoCISUConstants.VEHICLE_TYPE_SMUR):
-            set_value(
-                resource,
-                ResourcesInfoCISUConstants.VEHICLE_TYPE_PATH,
-                ResourcesInfoCISUConstants.VEHICLE_TYPE_SMUR,
-            )
-        else:
-            raise ConversionError(
-                f"No valid vehicle found for resource: {resource.get('resourceId')}."
-            )
+        logger.info(
+            "Replacing vehicleType %s with %s for ressource with id %s",
+            vehicle_type,
+            ResourcesInfoCISUConstants.VEHICLE_TYPE_VECTEUR_SANTE,
+            resourceId,
+        )
+        set_value(
+            resource,
+            ResourcesInfoCISUConstants.VEHICLE_TYPE_PATH,
+            ResourcesInfoCISUConstants.VEHICLE_TYPE_VECTEUR_SANTE,
+        )
 
     @classmethod
     def _keep_last_state(cls, resource: Dict[str, Any]) -> None:

--- a/converter/converter/cisu/resources_info/resources_info_cisu_converter.py
+++ b/converter/converter/cisu/resources_info/resources_info_cisu_converter.py
@@ -77,6 +77,8 @@ class ResourcesInfoCISUConverter(BaseCISUConverter):
                 ResourcesInfoCISUConstants.MISSION_ID_PATH,
             )
 
+            cls._translate_to_samu_vehicle_type(resource)
+
         return cls.format_rs_output_json(output_json, output_use_case_json)
 
     @classmethod
@@ -156,6 +158,34 @@ class ResourcesInfoCISUConverter(BaseCISUConverter):
         return ResourceUpdateResult(
             engaged_resources_updated=engaged_resources_updated,
             modified_status_resources=modified_status_resources,
+        )
+
+    @classmethod
+    def _translate_to_samu_vehicle_type(cls, resource: Dict[str, Any]) -> None:
+        """Translate a CISU vehicle type to its SAMU equivalent. Throws an error if no vehicleType is provided."""
+
+        vehicle_type = get_field_value(
+            resource, ResourcesInfoCISUConstants.VEHICLE_TYPE_PATH
+        )
+        resourceId = get_field_value(
+            resource, ResourcesInfoCISUConstants.RESOURCE_ID_KEY
+        )
+
+        if vehicle_type is None:
+            raise ConversionError(
+                f"No vehicle found in CISU resource for resource: {resourceId}."
+            )
+
+        logger.info(
+            "Replacing vehicleType %s with %s for ressource with id %s",
+            vehicle_type,
+            ResourcesInfoCISUConstants.VEHICLE_TYPE_SIS,
+            resourceId,
+        )
+        set_value(
+            resource,
+            ResourcesInfoCISUConstants.VEHICLE_TYPE_PATH,
+            ResourcesInfoCISUConstants.VEHICLE_TYPE_SIS,
         )
 
     @classmethod

--- a/converter/tests/cisu/test_resources_info_converter.py
+++ b/converter/tests/cisu/test_resources_info_converter.py
@@ -26,10 +26,11 @@ RS_RI_SCHEMA = TestHelper.load_schema("RS-RI.schema.json")
 _PATCH_GET_LAST_RC_RI_BY_CASE_ID = "converter.cisu.resources_info.resources_info_cisu_converter.get_last_rc_ri_by_case_id"
 _PATCH_GET_RS_MESSAGES_BY_CASE_ID = "converter.cisu.resources_info.resources_info_cisu_converter.get_rs_messages_by_case_id"
 
+# These usecases does not contain the minimal infomations to trigger
+# the traduction of a valid RC-RI (no state on resource).
 usecase_files_returning_no_converted_messages = [
     "RS-RI_Secondaire_RobertVermande.03.json",
     "RS-RI_partageRessources_LolaHalimi.03c.json",
-    "RS-RI_partageRessources_MonsieurX.03.json",
 ]
 
 all_usecase_files = TestHelper.get_json_files(

--- a/converter/tests/cisu/test_resources_info_converter.py
+++ b/converter/tests/cisu/test_resources_info_converter.py
@@ -500,8 +500,8 @@ def test_from_rs_to_cisu_no_persisted_rs_sr():
 
     rc_ri = get_cisu_content(result)
     assert rc_ri["resource"][0]["state"]["status"] == "RET-BASE"
-    # Two resources present originaly but only one valid vehicle type, so 1 resource expected
-    assert (len(rc_ri["resource"])) == 1
+    # Two resources present originaly and both are translated in the destination RC-RI
+    assert (len(rc_ri["resource"])) == 2
 
 
 def test_from_rs_to_cisu_no_state_but_persisted_rs_sr():

--- a/converter/tests/cisu/test_resources_info_converter.py
+++ b/converter/tests/cisu/test_resources_info_converter.py
@@ -162,10 +162,14 @@ def test_cisu_to_rs_breaking_changes():
 @pytest.mark.parametrize(
     "rs_vehicule_type,expected",
     [
-        pytest.param("SIS", "SIS", id="translates SIS to SIS"),
-        pytest.param("SIS.DRAGON", "SIS", id="translates SIS.DRAGON to SIS"),
-        pytest.param("SMUR", "SMUR", id="translates SMUR to SMUR"),
-        pytest.param("SMUR.VLM", "SMUR", id="translates SMUR.VLM to SMUR"),
+        pytest.param("SIS", "VECTEUR_SANTE", id="translates SIS to VECTEUR_SANTE"),
+        pytest.param(
+            "SIS.DRAGON", "VECTEUR_SANTE", id="translates SIS.DRAGON to VECTEUR_SANTE"
+        ),
+        pytest.param("SMUR", "VECTEUR_SANTE", id="translates SMUR to VECTEUR_SANTE"),
+        pytest.param(
+            "SMUR.VLM", "VECTEUR_SANTE", id="translates SMUR.VLM to VECTEUR_SANTE"
+        ),
     ],
 )
 def test_translate_vehicule_type_to_cisu(rs_vehicule_type, expected):
@@ -175,17 +179,17 @@ def test_translate_vehicule_type_to_cisu(rs_vehicule_type, expected):
 
 
 @pytest.mark.parametrize(
-    "rs_vehicule_type",
+    "rs_vehicule_type,expected",
     [
-        pytest.param("AUTREVEC", id="AUTREVEC is not mappable to CISU"),
-        pytest.param("FSI.HELIFSI", id="FSI.HELIFSI is not mappable to CISU"),
-        pytest.param("TSU.VSL", id="TSU.VSL is not mappable to CISU"),
+        pytest.param("SIS", "SIS", id="translates SIS to SIS"),
+        pytest.param("VECTEUR_SANTE", "SIS", id="translates VECTEUR_SANTE to SIS"),
+        pytest.param("unsuported", "SIS", id="translates unsuported to SIS"),
     ],
 )
-def test_translate_vehicule_type_to_cisu_raises_on_unmappable(rs_vehicule_type):
+def test_translate_vehicule_type_to_samu(rs_vehicule_type, expected):
     resource = {"vehicleType": rs_vehicule_type}
-    with pytest.raises(ConversionError):
-        ResourcesInfoCISUConverter._translate_to_cisu_vehicle_type(resource)
+    ResourcesInfoCISUConverter._translate_to_samu_vehicle_type(resource)
+    assert resource["vehicleType"] == expected
 
 
 # ---------------------------------------------------------------------------

--- a/converter/tests/fixtures/RC-RI/RC-RI_V3.0_exhaustive_fill.json
+++ b/converter/tests/fixtures/RC-RI/RC-RI_V3.0_exhaustive_fill.json
@@ -17,7 +17,7 @@
         "datetime": "2024-08-01T16:42:00+02:00",
         "resourceId": "fr.health.samu76A.resource.VLM12",
         "orgId": "fr.health.samu76A",
-        "vehicleType": "SMUR",
+        "vehicleType": "VECTEUR_SANTE",
         "name": "VLM 76 - A45"
       },
       {

--- a/converter/tests/fixtures/RC-RI/RC-RI_V3.0_with_position.json
+++ b/converter/tests/fixtures/RC-RI/RC-RI_V3.0_with_position.json
@@ -5,7 +5,7 @@
       {
         "resourceId": "fr.health.samu800.resource.VLM1",
         "orgId": "fr.health.samu800",
-        "vehicleType": "SMUR",
+        "vehicleType": "VECTEUR_SANTE",
         "name": "VLM 800-1",
         "state": {
           "datetime": "2024-08-01T16:42:00+02:00",


### PR DESCRIPTION
## 🔎 Détails

- Révision des règles de traduction du champ vehicleType dans les ressources du messages RC-RI
  - Dans le sens 18 vers 15, tous les types de ressource sont traduits en "SIS"
  - Dans le sens 15 vers 18, tous les types de ressource sont traduits en "VECTEUR_SANTE"

- Mise à jour des cas de tests unitaires pour la traduction du champ

## ☑️ Validation

Pre-requis :
- Se placer sur la branche `converter/vectuer-samu-conversion-handling`
- Lancer le converter

 ### Sens 18 vers 15

```
# Génération du message RC-RI
export EDXL=$(jq -n \
  --slurpfile env tests/fixtures/EDXL/edxl_envelope_fire_to_health.json \
  --slurpfile msg ../src/main/resources/sample/examples/RC-RI/RC-RI_Incendie_RaymondeLECCIA.02.json \
  '($env[0].edxl | .content[0].jsonContent.embeddedJsonContent.message += $msg[0])')

# Conversion
curl -s -X POST http://localhost:8090/convert \
  -H "Content-Type: application/json" \
  -d "$(jq -n --argjson edxl "$EDXL" \
    '{sourceVersion:"v3", targetVersion:"v3", cisuConversion: "true", edxl:$edxl}')" \
  > res.json

# Vérification du contenu dans res.json : le champ vehicleType contient toujours "SIS"
```

 ### Sens 15 vers 18
```
# Génération du message RS-RI
export EDXL=$(jq -n \
  --slurpfile env tests/fixtures/EDXL/edxl_envelope_health_to_fire.json \
  --slurpfile msg ../src/main/resources/sample/examples/RS-RI/RS-RI_partageRessources_MonsieurX.03.json \
  '($env[0].edxl | .content[0].jsonContent.embeddedJsonContent.message += $msg[0])')

# Conversion
curl -s -X POST http://localhost:8090/convert \
  -H "Content-Type: application/json" \
  -d "$(jq -n --argjson edxl "$EDXL" \
    '{sourceVersion:"v3", targetVersion:"v3", cisuConversion: "true", edxl:$edxl}')" \
  > res.json

# Vérification du contenu dans res.json : le champ vehicleType contient bien "VECTEUR_SANTE"
```

## 🔗 Ticket associé

[Asana](https://app.asana.com/1/1201445755223134/project/1214912630771690/task/1215721520440131?focus=true)
