### PR TITLE
Feat/add initial calltaker as custommap

### DIFF
--- a/converter/converter/cisu/create_case/create_case_cisu_constants.py
+++ b/converter/converter/cisu/create_case/create_case_cisu_constants.py
@@ -80,3 +80,7 @@ class CreateCaseCISUConstants:
     REFERENCE_VERSION_PATH = "$.referenceVersion"
 
     CREATION_PATH = "$.creation"
+
+    ADDITIONAL_INFORMATION_PATH = "$.additionalInformation"
+    CUSTOM_MAP_PATH = f"{ADDITIONAL_INFORMATION_PATH}.customMap"
+    INITIAL_ALERT_CALL_TAKER_ORG_PATH = f"{INITIAL_ALERT_CALL_TAKER_PATH}.organization"

--- a/converter/converter/cisu/create_case/create_case_cisu_converter.py
+++ b/converter/converter/cisu/create_case/create_case_cisu_converter.py
@@ -1,4 +1,4 @@
-from typing import Dict, Any
+from typing import Dict, Any, Optional
 import copy
 import random
 import string
@@ -9,8 +9,11 @@ from yaml import dump
 from converter.cisu.create_case.create_case_cisu_constants import (
     CreateCaseCISUConstants,
 )
+
 from converter.cisu.utils import add_to_initial_alert_notes
 from converter.constants import Constants
+from pydantic import BaseModel, Field
+
 from converter.utils import (
     delete_paths,
     get_field_value,
@@ -24,6 +27,25 @@ from converter.cisu.base_cisu_converter import BaseCISUConverter
 import logging
 
 logger = logging.getLogger(__name__)
+
+
+class CustomMap(BaseModel):
+    key: str = Field(
+        ...,
+        description="A valoriser avec le nom de la balise",
+    )
+    value: str = Field(
+        ...,
+        description="A valoriser avec la valeur associée à la clé",
+    )
+    label: Optional[str] = Field(
+        None,
+        description="A valoriser avec le libellé correspondant",
+    )
+    freetext: Optional[str] = Field(
+        None,
+        description="Informations complémentaires sur le contexte / utilisation de cette correspondance additionnelle",
+    )
 
 
 class CreateCaseCISUConverter(BaseCISUConverter):
@@ -165,6 +187,63 @@ class CreateCaseCISUConverter(BaseCISUConverter):
                 json_data, CreateCaseCISUConstants.MEDICAL_NOTE_PATH, medical_notes
             )
 
+        def clear_custom_map(json_data: Dict[str, Any]):
+            """clear the RC-EDA customMap field"""
+            initial_custom_map_array = get_field_value(
+                json_data, CreateCaseCISUConstants.CUSTOM_MAP_PATH
+            )
+            if initial_custom_map_array:
+                logger.debug("Found existing customMap in message. Clearing it.")
+                set_value(
+                    json_data,
+                    CreateCaseCISUConstants.CUSTOM_MAP_PATH,
+                    [],
+                )
+
+        def add_to_custom_map(json_data: Dict[str, Any], custom_map_entry: CustomMap):
+            initial_custom_map_array = get_field_value(
+                json_data, CreateCaseCISUConstants.CUSTOM_MAP_PATH
+            )
+            if not initial_custom_map_array:
+                initial_custom_map_array = []
+
+            # RC-EDA model forces cardinality of max 3 items for customMap field
+            if len(initial_custom_map_array) >= 3:
+                raise ValueError("The customMap already contains 3 items.")
+
+            initial_custom_map_array.append(custom_map_entry.model_dump())
+
+            set_value(
+                json_data,
+                CreateCaseCISUConstants.CUSTOM_MAP_PATH,
+                initial_custom_map_array,
+            )
+
+        def get_call_taker_org(json_data: Dict[str, Any]):
+            return get_field_value(
+                json_data, CreateCaseCISUConstants.INITIAL_ALERT_CALL_TAKER_ORG_PATH
+            )
+
+        def add_call_taker_org_to_custom_map(json_data: Dict[str, Any]):
+            logger.debug("Adding initialAlert callTaker organization as customMap")
+
+            # get initialalert.calltaker.organization from RC-EDA
+            calltaker_org = get_call_taker_org(json_data)
+
+            if calltaker_org is not None:
+                logger.debug("Adding initialAlert callTaker organization as customMap")
+                # create the customMap item
+                initialalert_calltaker = CustomMap(
+                    key="initialalert.calltaker.organization",
+                    label="Identifiant SDIS",
+                    value=calltaker_org,
+                    freetext="",
+                )
+
+                add_to_custom_map(json_data, initialalert_calltaker)
+
+            return json_data
+
         # Create independent envelope copy without usecase for output
         output_json = cls.copy_cisu_input_content(input_json)
 
@@ -190,6 +269,9 @@ class CreateCaseCISUConverter(BaseCISUConverter):
         merge_notes_freetext(output_use_case_json)
 
         add_victims_to_medical_notes(output_use_case_json, sender_id)
+
+        clear_custom_map(output_use_case_json)
+        add_call_taker_org_to_custom_map(output_use_case_json)
 
         # - Delete paths - /!\ It must be the last step
         logger.debug("Removing unnecessary paths")

--- a/converter/scripts/call_convert.sh
+++ b/converter/scripts/call_convert.sh
@@ -1,0 +1,111 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR=$(cd "$(dirname "$0")" && pwd)
+ENVELOPE_DEFAULT="$SCRIPT_DIR/../tests/fixtures/EDXL/edxl_envelope_health_to_health.json"
+CONVERTER_URL_DEFAULT="http://localhost:8083"
+
+usage() {
+  cat >&2 <<EOF
+Usage: $(basename "$0") <sourceVersion> <targetVersion> <useCase> [options]
+
+Positional arguments:
+  sourceVersion    e.g. v1, v2, v3, vactive (passed as-is)
+  targetVersion    e.g. v1, v2, v3, vactive (passed as-is)
+  useCase          path to a JSON file OR http(s) URL of the message payload
+
+Options:
+  --envelope <path|url>     EDXL envelope file or URL
+                            (default: tests/fixtures/EDXL/edxl_envelope_health_to_health.json)
+  --converter_url <url>     Converter base URL (default: http://localhost:8083)
+  --no-cisu                 Disable CISU conversion
+  -h, --help                Show this message
+
+Example:
+  $(basename "$0") v3 v2 HealthVersionConversion tests/fixtures/RS-RI/RS-RI_V3.0_exhaustive_fill.json
+EOF
+}
+
+ENVELOPE="$ENVELOPE_DEFAULT"
+CONVERTER_URL="$CONVERTER_URL_DEFAULT"
+CISU_CONVERSION=true
+POSITIONAL=()
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --envelope)
+      [[ $# -ge 2 ]] || { echo "Error: --envelope requires a value" >&2; usage; exit 1; }
+      ENVELOPE="$2"; shift 2;;
+    --converter_url)
+      [[ $# -ge 2 ]] || { echo "Error: --converter_url requires a value" >&2; usage; exit 1; }
+      CONVERTER_URL="$2"; shift 2;;
+    --no-cisu)
+      CISU_CONVERSION=false; shift;;
+    -h|--help)
+      usage; exit 0;;
+    --*)
+      echo "Error: unknown flag: $1" >&2; usage; exit 1;;
+    *)
+      POSITIONAL+=("$1"); shift;;
+  esac
+done
+
+if [[ ${#POSITIONAL[@]} -ne 3 ]]; then
+  echo "Error: expected 3 positional arguments, got ${#POSITIONAL[@]}" >&2
+  usage
+  exit 1
+fi
+
+SOURCE_VERSION="${POSITIONAL[0]}"
+TARGET_VERSION="${POSITIONAL[1]}"
+USECASE="${POSITIONAL[2]}"
+
+for dep in jq curl; do
+  if ! command -v "$dep" >/dev/null 2>&1; then
+    echo "Error: missing required dependency: $dep" >&2
+    exit 1
+  fi
+done
+
+read_source() {
+  local src="$1"
+  local label="$2"
+  if [[ "$src" =~ ^https?:// ]]; then
+    if ! curl -fsSL "$src"; then
+      echo "Error: failed to download $label from $src" >&2
+      return 1
+    fi
+  else
+    if [[ ! -f "$src" ]]; then
+      echo "Error: $label file not found: $src" >&2
+      return 1
+    fi
+    cat "$src"
+  fi
+}
+
+ENVELOPE_JSON=$(read_source "$ENVELOPE" "envelope") || exit 1
+USECASE_JSON=$(read_source "$USECASE" "useCase") || exit 1
+
+PAYLOAD=$(jq -n \
+  --argjson envelope "$ENVELOPE_JSON" \
+  --argjson usecase "$USECASE_JSON" \
+  --arg sourceVersion "$SOURCE_VERSION" \
+  --arg targetVersion "$TARGET_VERSION" \
+  --argjson cisuConversion "$CISU_CONVERSION" \
+  '{
+    sourceVersion: $sourceVersion,
+    targetVersion: $targetVersion,
+    cisuConversion: $cisuConversion,
+    edxl: ($envelope.edxl | .content[0].jsonContent.embeddedJsonContent.message |= (. + $usecase))
+  }')
+
+RESPONSE=$(curl -sS -X POST "$CONVERTER_URL/convert" \
+  -H "Content-Type: application/json" \
+  -d "$PAYLOAD")
+
+if printf '%s' "$RESPONSE" | jq . >/dev/null 2>&1; then
+  printf '%s' "$RESPONSE" | jq .
+else
+  printf '%s\n' "$RESPONSE"
+fi

--- a/converter/tests/cisu/__snapshots__/test_create_case_converter.ambr
+++ b/converter/tests/cisu/__snapshots__/test_create_case_converter.ambr
@@ -144,8 +144,10 @@
                 "additionalInformation": {
                   "customMap": [
                     {
-                      "key": "COMMERCIAL",
-                      "value": "IKEA Nantes"
+                      "key": "initialalert.calltaker.organization",
+                      "value": "fr.health.samu440",
+                      "label": "Identifiant SDIS",
+                      "freetext": ""
                     }
                   ]
                 },
@@ -313,8 +315,10 @@
                 "additionalInformation": {
                   "customMap": [
                     {
-                      "key": "COMMERCIAL",
-                      "value": "IKEA Nantes"
+                      "key": "initialalert.calltaker.organization",
+                      "value": "fr.health.samu440",
+                      "label": "Identifiant SDIS",
+                      "freetext": ""
                     }
                   ]
                 },

--- a/converter/tests/cisu/test_create_case_converter.py
+++ b/converter/tests/cisu/test_create_case_converter.py
@@ -3,6 +3,7 @@ from unittest.mock import patch
 from converter.cisu.create_case.create_case_cisu_converter import (
     CreateCaseCISUConverter,
 )
+from tests.cisu.helpers import get_edxl_message
 from tests.constants import TestConstants
 from tests.test_helpers import TestHelper
 import json
@@ -14,18 +15,32 @@ RS_EDA_SCHEMA = TestHelper.load_schema("RS-EDA.schema.json")
 RC_EDA_SCHEMA = TestHelper.load_schema("RC-EDA.schema.json")
 
 
+def additional_validation(result):
+    "Global additional validation (previously validate_health_format)"
+    assert "owner" in result, "Health format must contain owner field"
+    assert "additionalInformation" in result, (
+        "field additionalInformation should be present"
+    )
+    assert "customMap" in result["additionalInformation"], (
+        "field customMap should be present in additionalInformation"
+    )
+    custom_map_keys = [
+        entry["key"] for entry in result["additionalInformation"]["customMap"]
+    ]
+    assert "initialalert.calltaker.organization" in custom_map_keys, (
+        "initialalert.calltaker.organization must be present in customMap"
+    )
+
+
 def test_from_cisu_conversion_local():
     """Test conversion from CISU to Health format"""
-
-    def validate_health_format(result):
-        assert "owner" in result, "Health format must contain owner field"
 
     TestHelper.conversion_tests_runner(
         sample_dir=TestConstants.RC_EDA_TAG,
         envelope_file=TestConstants.EDXL_FIRE_TO_HEALTH_ENVELOPE_PATH,
         converter_method=CreateCaseCISUConverter.from_cisu_to_rs,
         target_schema=RS_EDA_SCHEMA,
-        additional_validation=validate_health_format,
+        additional_validation=additional_validation,
     )
 
 
@@ -42,15 +57,12 @@ def test_to_cisu_conversion_local():
 def test_from_cisu_conversion_v3():
     """Test conversion from CISU to Health format"""
 
-    def validate_health_format(result):
-        assert "owner" in result, "Health format must contain owner field"
-
     TestHelper.conversion_tests_runner(
         sample_dir=TestConstants.RC_EDA_TAG,
         envelope_file=TestConstants.EDXL_FIRE_TO_HEALTH_ENVELOPE_PATH,
         converter_method=CreateCaseCISUConverter.from_cisu_to_rs,
         target_schema=RS_EDA_SCHEMA,
-        additional_validation=validate_health_format,
+        additional_validation=additional_validation,
         online_tag="main",  # ToDo: migrate to "v3" once tag is available
     )
 
@@ -152,6 +164,7 @@ class TestSnapshotCreateCaseConverter:
         converter = CreateCaseCISUConverter
 
         output_data = converter.from_rs_to_cisu(message)
+
         assert json.dumps(output_data, indent=2) == snapshot
 
     @patch("converter.cisu.create_case.create_case_cisu_converter.random")
@@ -165,7 +178,6 @@ class TestSnapshotCreateCaseConverter:
         converter = CreateCaseCISUConverter
 
         output_data = converter.from_cisu_to_rs(message)
-
         assert json.dumps(output_data, indent=2) == snapshot
 
 
@@ -217,6 +229,86 @@ class TestVictimsCount(unittest.TestCase):
         self.assertEqual(
             self.converter.get_victim_count(self.converter, patients), {"count": "0"}
         )
+
+
+class TestInitialCallTaker(unittest.TestCase):
+    def setUp(self):
+        self.fixtures_folder_path = "tests/fixtures/RC-EDA/"
+        self.converter = CreateCaseCISUConverter
+
+    def test_initial_calltaker(self):
+
+        message = TestHelper.create_edxl_json_from_sample(
+            TestConstants.EDXL_FIRE_TO_HEALTH_ENVELOPE_PATH,
+            self.fixtures_folder_path + "RC-EDA_exhaustive_fill.json",
+        )
+
+        result_edxl = self.converter.from_cisu_to_rs(message)
+        result = get_edxl_message(result_edxl)["createCaseHealth"]
+
+        custom_map = result["additionalInformation"]["customMap"]
+        calltaker_entry = next(
+            (
+                e
+                for e in custom_map
+                if e["key"] == "initialalert.calltaker.organization"
+            ),
+            None,
+        )
+
+        self.assertIsNotNone(
+            calltaker_entry, "initialalert.calltaker.organization must be in customMap"
+        )
+        self.assertEqual(calltaker_entry["label"], "Identifiant SDIS")
+        self.assertIsNotNone(calltaker_entry["value"])
+
+    def test_custom_map_cleared_before_calltaker_added(self):
+        message = TestHelper.create_edxl_json_from_sample(
+            TestConstants.EDXL_FIRE_TO_HEALTH_ENVELOPE_PATH,
+            self.fixtures_folder_path + "RC-EDA_exhaustive_fill.json",
+        )
+
+        get_edxl_message(message)["createCase"].setdefault("additionalInformation", {})[
+            "customMap"
+        ] = [
+            {"key": "existing.key", "label": "Existing", "value": "val", "freetext": ""}
+        ]
+
+        result_edxl = self.converter.from_cisu_to_rs(message)
+        custom_map = get_edxl_message(result_edxl)["createCaseHealth"][
+            "additionalInformation"
+        ]["customMap"]
+        self.assertEqual(len(custom_map), 1)
+        self.assertEqual(custom_map[0]["key"], "initialalert.calltaker.organization")
+
+    def test_no_additional_information_if_empty_cutom_map_initially(self):
+        message = TestHelper.create_edxl_json_from_sample(
+            TestConstants.EDXL_FIRE_TO_HEALTH_ENVELOPE_PATH,
+            self.fixtures_folder_path + "RC-EDA_required_fields.json",
+        )
+        result_edxl = self.converter.from_cisu_to_rs(message)
+        additional_information = get_edxl_message(result_edxl)["createCaseHealth"].get(
+            "additionalInformation"
+        )
+        self.assertIsNone(additional_information)
+
+    def test_no_additional_information_if_calltaker_not_provided(self):
+        message = TestHelper.create_edxl_json_from_sample(
+            TestConstants.EDXL_FIRE_TO_HEALTH_ENVELOPE_PATH,
+            self.fixtures_folder_path + "RC-EDA_required_fields.json",
+        )
+
+        get_edxl_message(message)["createCase"].setdefault("additionalInformation", {})[
+            "customMap"
+        ] = [
+            {"key": "existing.key", "label": "Existing", "value": "val", "freetext": ""}
+        ]
+
+        result_edxl = self.converter.from_cisu_to_rs(message)
+        custom_map = get_edxl_message(result_edxl)["createCaseHealth"][
+            "additionalInformation"
+        ]["customMap"]
+        self.assertEqual(len(custom_map), 0)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## 🔎 Détails

Lors de la conversion CISU RC-EDA->RS-EDA, envoyer sous forme de clé/valeur des données non prévues dans le RS-EDA

Dans le sens 18->15, l'émetteur du messages RC-EDA est : fr.fire.sga (le système national de gestion des alertes) et le champ initialalert.calltaker.organization contient l'identifiant du SDIS concerné sous la forme fr.fire.XXX-cgo. Ce champ n'existe pas dans le RS-EDA donc l'identifiant du SDIS n'est pas transmis dans le cas d'une transco RC-EDA → RS-EDA

Dans le sens 15->18, le destinataire des messages (RC-EDA et RC-RI) doit être fr.fire.XXX-cgo donc l'éditeur a besoin de cette information pour savoir où envoyer les messages de ressources suite à un partage d'affaire par NexSIS. Il pourrait le paramétrer pour les SAMU qui travaillent avec un seul SDIS mais ce ne sera pas possible pour les SAMU qui échangent des dossiers avec plusieurs SDIS.

On ajoute alors, lors de la conversion 15 -> 18, l'expéditeur réel sous forme de customMap.


## Validation

Lancer le setup local : 

dans Config : 

```bash
gmake start EXCLUDE=lrm-back,lrm-front,dispatcher,rabbitmq,converter
```

Lancer ensuite le converter. Se placer dans `SAMU-Hub-Modeles/converter` et lancer : 

```bash
FLASK_APP=converter.converter \
FLASK_ENV=development \
FLASK_DEBUG=1 \
uv run python -m flask run --port 8083
```

Puis dans un nouveau terminal, lancer :

```bash
./scripts/call_convert.sh \
    v3 v3 \
    <path_to_repo_model>/SAMU-Hub-Modeles/src/main/resources/sample/examples/RC-EDA/RC-EDA_Incendie_RaymondeLECCIA.01.json \
    --envelope tests/fixtures/EDXL/edxl_envelope_fire_to_health.json \
    | jq '.converted_messages[0].content[0].jsonContent.embeddedJsonContent.message.createCaseHealth.additionalInformation'
```

Output attendu : 
```json
{
  "customMap": [
    {
    "freetext": "",
    "key": "initialalert.calltaker.organization",
    "label": "Identifiant SDIS",
    "value": "fr.fire.sisXXX.cga-XXX"
     }
  ]
}
```


## 🔗 Ticket associé

[Asana](https://app.asana.com/1/1201445755223134/project/1214912630771690/task/1215924250089557?focus=true)
