### PR TITLE
Feat/RC to RS conversion remove custom map freetext

### DIFF
--- a/converter/converter/cisu/create_case/create_case_cisu_converter.py
+++ b/converter/converter/cisu/create_case/create_case_cisu_converter.py
@@ -175,7 +175,6 @@ class CreateCaseCISUConverter(BaseCISUConverter):
                 key="qualification.victims.count",
                 label="Nombre de patients-victimes",
                 value=count,
-                freetext="Indique le nombre de victimes selon la nomenclature du référentiel CISU",
             )
 
             add_to_custom_map(json_data, victim_count)
@@ -194,7 +193,6 @@ class CreateCaseCISUConverter(BaseCISUConverter):
                 key="qualification.victims.mainVictim",
                 label="Type du patient-victime principal",
                 value=main_victim,
-                freetext="Identifie le type de la principale victime (celle dont l'état de santé provoque le déclenchement de l'envoi des secours) selon la nomenclature du référentiel CISU",
             )
 
             add_to_custom_map(json_data, main_victim)
@@ -251,7 +249,9 @@ class CreateCaseCISUConverter(BaseCISUConverter):
             if len(initial_custom_map_array) >= 3:
                 raise ValueError("The customMap already contains 3 items.")
 
-            initial_custom_map_array.append(custom_map_entry.model_dump())
+            initial_custom_map_array.append(
+                custom_map_entry.model_dump(exclude_none=True)
+            )
 
             set_value(
                 json_data,
@@ -277,7 +277,6 @@ class CreateCaseCISUConverter(BaseCISUConverter):
                     key="initialalert.calltaker.organization",
                     label="Identifiant SDIS",
                     value=calltaker_org,
-                    freetext="",
                 )
 
                 add_to_custom_map(json_data, initialalert_calltaker)

--- a/converter/pyproject.toml
+++ b/converter/pyproject.toml
@@ -60,6 +60,11 @@ dev = [
     "mongomock>=4.1.2",
 ]
 
+[tool.mypy]
+plugins = [
+    "pydantic.mypy"
+]
+
 [[tool.mypy.overrides]]
 module = ["jsonpath_ng.*", "prometheus_flask_exporter.*"]
 ignore_missing_imports = true

--- a/converter/tests/cisu/__snapshots__/test_create_case_converter.ambr
+++ b/converter/tests/cisu/__snapshots__/test_create_case_converter.ambr
@@ -146,20 +146,17 @@
                     {
                       "key": "qualification.victims.count",
                       "value": "1",
-                      "label": "Nombre de patients-victimes",
-                      "freetext": "Indique le nombre de victimes selon la nomenclature du r\u00e9f\u00e9rentiel CISU"
+                      "label": "Nombre de patients-victimes"
                     },
                     {
                       "key": "qualification.victims.mainVictim",
                       "value": "ADULTE",
-                      "label": "Type du patient-victime principal",
-                      "freetext": "Identifie le type de la principale victime (celle dont l'\u00e9tat de sant\u00e9 provoque le d\u00e9clenchement de l'envoi des secours) selon la nomenclature du r\u00e9f\u00e9rentiel CISU"
+                      "label": "Type du patient-victime principal"
                     },
                     {
                       "key": "initialalert.calltaker.organization",
                       "value": "fr.health.samu440",
-                      "label": "Identifiant SDIS",
-                      "freetext": ""
+                      "label": "Identifiant SDIS"
                     }
                   ]
                 },
@@ -329,20 +326,17 @@
                     {
                       "key": "qualification.victims.count",
                       "value": "1",
-                      "label": "Nombre de patients-victimes",
-                      "freetext": "Indique le nombre de victimes selon la nomenclature du r\u00e9f\u00e9rentiel CISU"
+                      "label": "Nombre de patients-victimes"
                     },
                     {
                       "key": "qualification.victims.mainVictim",
                       "value": "ADULTE",
-                      "label": "Type du patient-victime principal",
-                      "freetext": "Identifie le type de la principale victime (celle dont l'\u00e9tat de sant\u00e9 provoque le d\u00e9clenchement de l'envoi des secours) selon la nomenclature du r\u00e9f\u00e9rentiel CISU"
+                      "label": "Type du patient-victime principal"
                     },
                     {
                       "key": "initialalert.calltaker.organization",
                       "value": "fr.health.samu440",
-                      "label": "Identifiant SDIS",
-                      "freetext": ""
+                      "label": "Identifiant SDIS"
                     }
                   ]
                 },


### PR DESCRIPTION
## 🔎 Détails

Le champ "freetext" du customMap introduit dans https://github.com/ansforge/SAMU-Hub-Modeles/pull/427 ne sera pas utilisé par les éditeurs ; étant optionnel, on préfère le retirer. Plusieurs changements : 

- ajout de 
```bash
[tool.mypy]
plugins = [
    "pydantic.mypy"
]
```

Dans le converter/pyproject.toml. 

### Pourquoi 

sinon lefthook ne considère pas le champ `freetext` du `CustomMap` comme optionnel, et faire :

```python
initialalert_calltaker = CustomMap(
                    key="initialalert.calltaker.organization",
                    label="Identifiant SDIS",
                    value=calltaker_org,
                   # sans le champ 'freetext'
                )
```

Levait l'erreur lefthook :

```bash
converter/cisu/create_case/create_case_cisu_converter.py:174: error: Missing named argument "freetext" for "CustomMap"  [call-arg]
converter/cisu/create_case/create_case_cisu_converter.py:192: error: Missing named argument "freetext" for "CustomMap"  [call-arg]
```

Alors que dans la définition de la classe, on a bien (et c'est du valid pydantic) : 

```python
class CustomMap(BaseModel):
    key: str = Field(..., description="A valoriser avec le nom de la balise")
    value: str = Field(...,description="A valoriser avec la valeur associée à la clé")
    label: Optional[str] = Field(None, description="A valoriser avec le libellé correspondant")
    freetext: Optional[str] = Field(None,description="Informations complémentaires sur le contexte / utilisation de cette correspondance additionnelle")
```

J'ai également ajouté  le param `exclude_none=True` au `custom_map_entry.model_dump` de pydantic, car sinon le freetext était inclus avec sa valeur par défaut : 

#### avant
```json
{
      "freetext": null,
      "key": "qualification.victims.count",
      "label": "Nombre de patients-victimes",
      "value": "NON DEFINI"
}
```

#### après

```json
# plus de freetext
{
      "key": "qualification.victims.count",
      "label": "Nombre de patients-victimes",
      "value": "NON DEFINI"
}
```

## 🔗 Ticket associé

[Asana](https://app.asana.com/1/1201445755223134/project/1215591420809463/task/1216164573044491?focus=true)
