### PR TITLE
chore: add renovate

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -15,12 +15,14 @@
       "description": "Mises à jour des GitHub Actions",
       "matchManagers": ["github-actions"],
       "groupName": "github-actions updates",
-      "separateMajorMinor": false
+      "separateMajorMinor": false,
+      "enabled": true
     },
     {
       "description": "Mises à jour des dépendances - Converter",
       "matchFileNames": ["converter/**"],
-      "groupName": "converter updates"
+      "groupName": "converter updates",
+      "enabled": true
     }
   ]
 }

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,0 +1,26 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": ["config:recommended"],
+  "schedule": ["on monday"],
+  "prHourlyLimit": 0,
+  "minimumReleaseAge": "14 days",
+  "automerge": false,
+  "packageRules": [
+    {
+      "description": "Desactivation globale de renovate",
+      "matchFileNames": ["*/**"],
+      "enabled": false
+    },
+    {
+      "description": "Mises à jour des GitHub Actions",
+      "matchManagers": ["github-actions"],
+      "groupName": "github-actions updates",
+      "separateMajorMinor": false
+    },
+    {
+      "description": "Mises à jour des dépendances - Converter",
+      "matchFileNames": ["converter/**"],
+      "groupName": "converter updates"
+    }
+  ]
+}


### PR DESCRIPTION
## 🔎 Détails

Setup de renovate pour gérer les dépendances sur l'application converter et les github-actions utilisées dans le workflow du répo.

## 📄 Documentation

[Spec](https://ans-esante.atlassian.net/wiki/spaces/HUB/pages/2025226257/Gestion+des+d+pendances)
