### PR TITLE
chore(ci): add authentication for DHI

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -5,6 +5,17 @@
   "prHourlyLimit": 0,
   "minimumReleaseAge": "14 days",
   "automerge": false,
+  "registryAliases": {
+    "dhi.io": "dhi.io"
+  },
+  "hostRules": [
+    {
+      "matchHost": "dhi.io",
+      "hostType": "docker",
+      "username": "{{ secrets.DHI_USERNAME }}",
+      "password": "{{ secrets.DHI_PASSWORD }}"
+    }
+  ],
   "packageRules": [
     {
       "description": "Desactivation globale de renovate",

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -16,24 +16,21 @@
       "password": "{{ secrets.DHI_PASSWORD }}"
     }
   ],
+  "includePaths": [
+    "converter/**",
+    ".github/workflows/**"
+  ],
   "packageRules": [
-    {
-      "description": "Desactivation globale de renovate",
-      "matchFileNames": ["*/**"],
-      "enabled": false
-    },
     {
       "description": "Mises à jour des GitHub Actions",
       "matchManagers": ["github-actions"],
-      "groupName": "github-actions updates",
-      "separateMajorMinor": false,
-      "enabled": true
+      "groupName": "github-actions",
+      "separateMajorMinor": false
     },
     {
       "description": "Mises à jour des dépendances - Converter",
       "matchFileNames": ["converter/**"],
-      "groupName": "converter updates",
-      "enabled": true
+      "groupName": "converter dependencies"
     }
   ]
 }


### PR DESCRIPTION
## 🔎 Détails

Actuellement, les jobs Renovate de vérification des versions des dépendances sont en échec à cause d'erreurs de résolutions de certains "packages" (au sens Renovate).

<img width="1208" height="335" alt="Capture d’écran 2026-08-03 à 14 31 45" src="https://github.com/user-attachments/assets/23a4985b-1a53-480c-bedc-681d5e0a9846" />

Fix :
- Ajout d'un alias ainsi que de credentials pour le registry Docker dhi.io (permettant à Renovate de vérifier les dépendances dans les Dockerfiles).
