### PR TITLE
[ Converter / Nomenclatures ] nettoyage script

### DIFF
--- a/converter/converter/nomenclatures/from_cisu_to_rs/whats_happen.py
+++ b/converter/converter/nomenclatures/from_cisu_to_rs/whats_happen.py
@@ -2,7 +2,7 @@
 
 MAP: dict[str, dict[str, str] | None] = {
     "C02.05.03": {
-        "code": "Autre ",
+        "code": "C02.18.00",
         "label": "Problème psychiatrique, menace de suicide",
     },
     "C02.16.02": {"code": "C02.16.00", "label": "Autre atteinte aux personnes"},

--- a/converter/resources/export_mapping_nomenclatures.csv
+++ b/converter/resources/export_mapping_nomenclatures.csv
@@ -1,5 +1,5 @@
 ﻿Champ,Balise,Version code reçu,Code reçu,Libellé reçu,Version code transmis,Code à transmettre,Libellé à transmettre,VALIDATION ANSC,VALIDATION ANS,Observation
-Circonstances Natures de Faits,$.qualification.whatsHappen,1.9,C02.05.03,Atteinte aux personnesPsychiatrique,2.3,Autre ,"Problème psychiatrique, menace de suicide",OK,OK,
+Circonstances Natures de Faits,$.qualification.whatsHappen,1.9,C02.05.03,Atteinte aux personnesPsychiatrique,2.3,C02.18.00,"Problème psychiatrique, menace de suicide",OK,OK,
 Circonstances Natures de Faits,$.qualification.whatsHappen,1.9,C02.16.02,Atteinte aux personnesAutre type d’atteinte aux personnes,2.3,C02.16.00,Autre atteinte aux personnes,OK,OK,
 Circonstances Natures de Faits,$.qualification.whatsHappen,1.9,C04.07.00,Feu à l'air libre,2.3,C04.08.00,Autre type d’incendie,OK,OK,
 Circonstances Natures de Faits,$.qualification.whatsHappen,1.9,C04.07.01,IncendieFeu de produits de classe A,2.3,C04.08.00,Autre type d’incendie,OK,OK,

--- a/converter/resources/export_mapping_nomenclatures.csv
+++ b/converter/resources/export_mapping_nomenclatures.csv
@@ -1,579 +1,694 @@
-﻿Champ,Balise,Version code reçu,Code reçu,Libellé reçu,Version code transmis,Code à transmettre,Libellé à transmettre,VALIDATION ANSC,VALIDATION ANS,Observation
-Circonstances Natures de Faits,$.qualification.whatsHappen,1.9,C02.05.03,Atteinte aux personnesPsychiatrique,2.3,C02.18.00,"Problème psychiatrique, menace de suicide",OK,OK,
-Circonstances Natures de Faits,$.qualification.whatsHappen,1.9,C02.16.02,Atteinte aux personnesAutre type d’atteinte aux personnes,2.3,C02.16.00,Autre atteinte aux personnes,OK,OK,
-Circonstances Natures de Faits,$.qualification.whatsHappen,1.9,C04.07.00,Feu à l'air libre,2.3,C04.08.00,Autre type d’incendie,OK,OK,
-Circonstances Natures de Faits,$.qualification.whatsHappen,1.9,C04.07.01,IncendieFeu de produits de classe A,2.3,C04.08.00,Autre type d’incendie,OK,OK,
-Circonstances Natures de Faits,$.qualification.whatsHappen,1.9,C04.07.02,IncendieFeu de produits de classe B,2.3,C04.08.00,Autre type d’incendie,OK,OK,
-Circonstances Natures de Faits,$.qualification.whatsHappen,1.9,C04.07.03,IncendieFeu de produits de classe C,2.3,C04.08.00,Autre type d’incendie,OK,OK,
-Circonstances Natures de Faits,$.qualification.whatsHappen,1.9,C04.07.04,IncendieFeu de produits de classe D,2.3,C04.08.00,Autre type d’incendie,OK,OK,
-Circonstances Natures de Faits,$.qualification.whatsHappen,1.9,C04.09.00,Alarme incendie,2.3,C11.01.01,Alarme incendie,OK,OK,
-Circonstances Natures de Faits,$.qualification.whatsHappen,1.9,C07.03.00,Ordre public,2.3,C07.00.00,Ordre public,OK,OK,
-Circonstances Natures de Faits,$.qualification.whatsHappen,1.9,C07.03.01,Ordre publicDifférend familial,2.3,C02.19.01,Différend familial,OK,OK,
-Circonstances Natures de Faits,$.qualification.whatsHappen,1.9,C07.03.02,Ordre publicNon représentation d’enfant,2.3,C02.19.02,Non représentation d’enfant,OK,OK,
-Circonstances Natures de Faits,$.qualification.whatsHappen,1.9,C07.03.03,Ordre publicDifférend de voisinage,2.3,C02.19.03,Différend de voisinage,OK,OK,
-Circonstances Natures de Faits,$.qualification.whatsHappen,1.9,C07.03.04,Ordre publicAutres différends,2.3,C02.19.04,Autre différend,OK,OK,
-Circonstances Natures de Faits,$.qualification.whatsHappen,1.9,C07.03.05,Ordre publicLitiges,2.3,C02.19.05,Litige,OK,OK,
-Circonstances Natures de Faits,$.qualification.whatsHappen,1.9,C10.01.07,Disparitions et découvertesRecherche secours investigation,2.3,C10.01.00,Disparition ou découverte d’individu,OK,OK,
-Circonstances Natures de Faits,$.qualification.whatsHappen,1.9,C10.02.00,Decouverte de cadavre,2.3,C02.17.00,Découverte de cadavre/mort suspecte,OK,OK,
-Circonstances Natures de Faits,$.qualification.whatsHappen,1.9,C10.02.01,Disparitions et découvertesMort a priori suspecte,2.3,C02.17.01,Découverte de cadavre,OK,OK,
-Circonstances Natures de Faits,$.qualification.whatsHappen,1.9,C10.02.02,Disparitions et découvertesMort a priori naturelle,2.3,C02.17.01,Découverte de cadavre,OK,OK,
-Circonstances Natures de Faits,$.qualification.whatsHappen,2.3,C02.17.00,Découverte de cadavre/mort suspecte,1.9,C10.02.01,Mort suspecte,OK,OK,
-Circonstances Natures de Faits,$.qualification.whatsHappen,2.3,C02.17.01,Découverte de cadavre,1.9,C10.02.01,Mort suspecte,OK,OK,
-Circonstances Natures de Faits,$.qualification.whatsHappen,2.3,C02.17.02,Mort suspecte,1.9,C10.02.01,Mort suspecte,OK,OK,
-Circonstances Natures de Faits,$.qualification.whatsHappen,2.3,C02.18.00,"Problème psychiatrique, menace de suicide",1.9,C02.05.03,Psychiatrique,OK,OK,
-Circonstances Natures de Faits,$.qualification.whatsHappen,2.3,C02.19.00,Différends et litiges inter-personnels,1.9,C07.03.00,Différends et litiges inter-personnels,OK,OK,
-Circonstances Natures de Faits,$.qualification.whatsHappen,2.3,C02.19.01,Différend familial,1.9,C07.03.01,Ordre publicDifférend familial,OK,OK,
-Circonstances Natures de Faits,$.qualification.whatsHappen,2.3,C02.19.02,Non représentation d’enfant,1.9,C07.03.02,Ordre publicNon représentation d’enfant,OK,OK,
-Circonstances Natures de Faits,$.qualification.whatsHappen,2.3,C02.19.03,Différend de voisinage,1.9,C07.03.03,Ordre publicDifférend de voisinage,OK,OK,
-Circonstances Natures de Faits,$.qualification.whatsHappen,2.3,C02.19.04,Autres différends,1.9,C07.03.04,Ordre publicAutres différends,OK,OK,
-Circonstances Natures de Faits,$.qualification.whatsHappen,2.3,C02.19.05,Litiges,1.9,C07.03.05,Ordre publicLitiges,OK,OK,
-Circonstances Natures de Faits,$.qualification.whatsHappen,2.3,C04.01.12,Incendie engin de chantier ou agricole,1.9,C04.01.00,Incendie d'un moyen de transport / véhicule,OK,OK,
-Circonstances Natures de Faits,$.qualification.whatsHappen,2.3,C04.01.13,Incendie plusieurs véhicules légers,1.9,C04.01.01,"Véhicule léger, fourgon",OK,OK,
-Circonstances Natures de Faits,$.qualification.whatsHappen,2.3,C04.01.14,Incendie Tram / tramway,1.9,C04.01.05,Train de voyageurs,OK,OK,
-Circonstances Natures de Faits,$.qualification.whatsHappen,2.3,C04.01.15,Incendie bateau de plaisance,1.9,C04.01.07,Bateau de voyageurs,OK,OK,
-Circonstances Natures de Faits,$.qualification.whatsHappen,2.3,C04.01.16,Incendie bateau de pêche,1.9,C04.01.08,Bateau de marchandises,OK,OK,
-Circonstances Natures de Faits,$.qualification.whatsHappen,2.3,C04.01.17,Incendie bateau de guerre,1.9,C04.01.08,Bateau de marchandises,OK,OK,
-Circonstances Natures de Faits,$.qualification.whatsHappen,2.3,C04.01.18,Incendie ULM / planeur / mongolfière,1.9,C04.01.10,Aéronef de voyageurs,OK,OK,
-Circonstances Natures de Faits,$.qualification.whatsHappen,2.3,C04.01.19,Incendie aéronef de tourisme,1.9,C04.01.10,Aéronef de voyageurs,OK,OK,
-Circonstances Natures de Faits,$.qualification.whatsHappen,2.3,C04.02.05,Incendie d'ERP avec locaux à sommeil,1.9,C04.02.00,Incendie d'un bâtiment,OK,OK,
-Circonstances Natures de Faits,$.qualification.whatsHappen,2.3,C04.02.06,Incendie d'ERP sans locaux à sommeil,1.9,C04.02.00,Incendie d'un bâtiment,OK,OK,
-Circonstances Natures de Faits,$.qualification.whatsHappen,2.3,C04.05.01,Incendie de haie / herbes sèches,1.9,C04.05.00,Incendie de forêt / végétation,OK,OK,
-Circonstances Natures de Faits,$.qualification.whatsHappen,2.3,C04.05.02,Feu de chaumes / récoltes,1.9,C04.05.00,Incendie de forêt / végétation,OK,OK,
-Circonstances Natures de Faits,$.qualification.whatsHappen,2.3,C04.05.03,Feu de broussailles,1.9,C04.05.00,Incendie de forêt / végétation,OK,OK,
-Circonstances Natures de Faits,$.qualification.whatsHappen,2.3,C04.05.04,Feu de forêt,1.9,C04.05.00,Incendie de forêt / végétation,OK,OK,
-Circonstances Natures de Faits,$.qualification.whatsHappen,2.3,C04.10.00,Incendie d'un élément / structure,1.9,C04.02.00,Incendie d'un bâtiment,OK,OK,
-Circonstances Natures de Faits,$.qualification.whatsHappen,2.3,C04.10.01,Feu de cheminée,1.9,C04.02.00,Incendie d'un bâtiment,OK,OK,
-Circonstances Natures de Faits,$.qualification.whatsHappen,2.3,C04.10.02,Incendie d'origine électrique,1.9,C04.08.00,Autre type d’incendie,OK,OK,
-Circonstances Natures de Faits,$.qualification.whatsHappen,2.3,C04.10.03,Autre feu d'un élément / structure,1.9,C04.08.00,Autre type d’incendie,OK,OK,
-Circonstances Natures de Faits,$.qualification.whatsHappen,2.3,C04.11.00,Fumée suspecte / levée de doute,1.9,C04.00.00,Incendie,OK,OK,
-Circonstances Natures de Faits,$.qualification.whatsHappen,2.3,C06.03.07,Refus d'obtempérer,1.9,C06.03.00,Suspicion d'infractions,OK,OK,
-Circonstances Natures de Faits,$.qualification.whatsHappen,2.3,C07.02.01,Affrontement bande,1.9,C07.02.00,Violence urbaine,OK,OK,
-Circonstances Natures de Faits,$.qualification.whatsHappen,2.3,C07.02.02,Dégradation mobilier urbain,1.9,C07.13.00,Autres troubles à l’ordre public,OK,OK,
-Circonstances Natures de Faits,$.qualification.whatsHappen,2.3,C07.02.03,Incendie,1.9,C04.08.00,Autre type d’incendie,OK,OK,
-Circonstances Natures de Faits,$.qualification.whatsHappen,2.3,C07.02.04,Autres violences urbaines,1.9,C07.02.00,Violence urbaine,OK,OK,
-Circonstances Natures de Faits,$.qualification.whatsHappen,2.3,C08.01.01,Inondation - montée des eaux inquiétante,1.9,C08.01.00,Inondation,OK,OK,
-Circonstances Natures de Faits,$.qualification.whatsHappen,2.3,C08.01.02,"Inondation d'un batiment, local",1.9,C08.01.00,Inondation,OK,OK,
-Circonstances Natures de Faits,$.qualification.whatsHappen,2.3,C08.05.01,Vent / Tempête avec chute d'arbres,1.9,C08.05.00,Vent / Tempête,OK,OK,
-Circonstances Natures de Faits,$.qualification.whatsHappen,2.3,C08.05.02,Vent / Tempête avec dommages sur toitures,1.9,C08.05.00,Vent / Tempête,OK,OK,
-Circonstances Natures de Faits,$.qualification.whatsHappen,2.3,C08.06.01,Éboulement / Effondrement de bâtiment,1.9,C08.06.00,Éboulement / effondrement,OK,OK,
-Circonstances Natures de Faits,$.qualification.whatsHappen,2.3,C08.06.02,Éboulement / Effondrement de carrière,1.9,C08.06.00,Éboulement / effondrement,OK,OK,
-Circonstances Natures de Faits,$.qualification.whatsHappen,2.3,C08.06.03,"Autre éboulement, effondrement",1.9,C08.06.00,Éboulement / effondrement,OK,OK,
-Circonstances Natures de Faits,$.qualification.whatsHappen,2.3,C08.08.03,Pollution aérienne,1.9,C08.08.00,Aléas naturel / environnemental / météorologique,OK,OK,
-Circonstances Natures de Faits,$.qualification.whatsHappen,2.3,C08.08.04,Pollution fut / bidon suspect,1.9,C08.08.00,Aléas naturel / environnemental / météorologique,OK,OK,
-Circonstances Natures de Faits,$.qualification.whatsHappen,2.3,C09.03.02,Fuite de gaz enflammée (réseau),1.9,C09.03.01,Fuite de gaz importante,OK,OK,
-Circonstances Natures de Faits,$.qualification.whatsHappen,2.3,C09.03.03,Fuite de gaz non enflammée (réseau),1.9,C09.03.01,Fuite de gaz importante,OK,OK,
-Circonstances Natures de Faits,$.qualification.whatsHappen,2.3,C09.03.04,Fuite de gaz sur bouteille,1.9,C09.03.00,Fuite de gaz,OK,OK,
-Circonstances Natures de Faits,$.qualification.whatsHappen,2.3,C09.04.03,Vapeur sous pression / chauffage urbain,1.9,C09.04.02,Fuite de fluides gazeux,OK,OK,
-Circonstances Natures de Faits,$.qualification.whatsHappen,2.3,C09.05.01,Immeuble en péril,1.9,C09.00.00,Aléas technologique ou technique,OK,OK,
-Circonstances Natures de Faits,$.qualification.whatsHappen,2.3,C09.05.02,Menace ou chute de matériaux,1.9,C09.00.00,Aléas technologique ou technique,OK,OK,
-Circonstances Natures de Faits,$.qualification.whatsHappen,2.3,C09.06.01,Panne d’ascenseur avec présence de personne vulnérable,1.9,C09.06.00,Panne d’ascenseur,OK,OK,
-Circonstances Natures de Faits,$.qualification.whatsHappen,2.3,C09.06.02,Panne d’ascenseur vide d'occupant,1.9,C09.06.00,Panne d’ascenseur,OK,OK,
-Circonstances Natures de Faits,$.qualification.whatsHappen,2.3,C11.01.01,Alarme incendie,1.9,C11.01.00,Alarme,OK,OK,
-Circonstances Natures de Faits,$.qualification.whatsHappen,2.3,C11.01.02,Alarme vol / intrusion,1.9,C11.01.00,Alarme,OK,OK,
-Circonstances Natures de Faits,$.qualification.whatsHappen,2.3,C11.01.03,Téléalarme secours à personne (applications),1.9,C11.01.00,Alarme,OK,OK,
-Circonstances Natures de Faits,$.qualification.whatsHappen,2.3,C11.01.04,Alarme dispositif travailleur isolé,1.9,C11.01.00,Alarme,OK,OK,
-Circonstances Natures de Faits,$.qualification.whatsHappen,2.3,C11.01.05,Simple alarme sans précision,1.9,C11.01.00,Alarme,OK,OK,
-Circonstances Natures de Faits,$.qualification.whatsHappen,2.3,C11.05.04,Problème technique sur un véhicule,1.9,C11.05.00,Autre nature de fait,OK,OK,
-Circonstances Natures de Faits,$.qualification.whatsHappen,2.3,C11.05.05,Obstruction de chaussée,1.9,C11.05.00,Autre nature de fait,OK,OK,
-Circonstances Natures de Faits,$.qualification.whatsHappen,2.3,C11.05.06,Obstruction de voie ferrée,1.9,C11.05.00,Autre nature de fait,OK,OK,
-Circonstances Natures de Faits,$.qualification.whatsHappen,2.3,C11.05.07,Obstruction de voie naviguable,1.9,C11.05.00,Autre nature de fait,OK,OK,
-Circonstances Natures de Faits,$.qualification.whatsHappen,2.3,C11.07.00,Requisition judiciaire,1.9,C11.00.00,Autre nature de fait,OK,OK,
-Circonstances Natures de Faits,$.qualification.whatsHappen,2.3,C11.08.00,Odeur suspecte,1.9,C11.00.00,Autre nature de fait,OK,OK,
-Motif de recours médico secouriste,$.qualification.healthMotive,1.9,M20.00,Urgences vitales,2.3,M08.00.00,Personne inconsciente ,OK,OK,le moins mauvais
-Motif de recours médico secouriste,$.qualification.healthMotive,1.9,M22.00,Personne inconsciente,2.3,M08.00.00,Personne inconsciente ,OK,OK,
-Motif de recours médico secouriste,$.qualification.healthMotive,1.9,M22.01,Pas de mouvement ventilatoire,2.3,M08.01.00,Personne en arrêt ventilatoire,OK,OK,
-Motif de recours médico secouriste,$.qualification.healthMotive,1.9,M22.11,Arrêt cardio-respiratoire,2.3,M08.02.00,Personne en arrêt cardio-respiratoire,OK,OK,
-Motif de recours médico secouriste,$.qualification.healthMotive,1.9,M22.21,Inconscient qui respire,2.3,M08.03.00,Personne inconsciente qui respire,OK,OK,
-Motif de recours médico secouriste,$.qualification.healthMotive,1.9,M24.00,Hémorragies / Saignements,2.3,M09.00.00,Hémorragies / Saignements ,OK,OK,
-Motif de recours médico secouriste,$.qualification.healthMotive,1.9,M24.01,Hémorragie ne pouvant être stoppée,2.3,M09.01.00,Hémorragie ne pouvant être stoppée,OK,OK,
-Motif de recours médico secouriste,$.qualification.healthMotive,1.9,M24.02,Hémorragie ne pouvant être stoppée - Epistaxis non stoppée par la compression,2.3,M09.01.01,Epitaxis non stoppée par compression,OK,OK,
-Motif de recours médico secouriste,$.qualification.healthMotive,1.9,M24.11,Hémorragie,2.3,M09.00.00,Hémorragies / Saignements ,OK,OK,
-Motif de recours médico secouriste,$.qualification.healthMotive,1.9,M24.21,Hémorragie extériorisée,2.3,M09.02.00,Hémorragie extériorisée,OK,OK,
-Motif de recours médico secouriste,$.qualification.healthMotive,1.9,M24.25,Hémorragie extériorisée - Hémorragie digestive (haute ou basse),2.3,M09.02.01,Hémorragie digestive (haute ou basse) extériorirée,OK,OK,
-Motif de recours médico secouriste,$.qualification.healthMotive,1.9,M24.26,Hémorragie extériorisée - Malaise,2.3,M09.02.02,Hémorragie extériorisée avec malaise ,OK,OK,
-Motif de recours médico secouriste,$.qualification.healthMotive,1.9,M24.27,Hémorragie extériorisée - Crache du sang en toussant,2.3,M09.02.03,Crache du sang hémoptysie,OK,OK,
-Motif de recours médico secouriste,$.qualification.healthMotive,1.9,M24.28,Hémorragie extériorisée - Saignement peut être stoppé par compression,2.3,M09.02.04,Saignement stoppé par compression,OK,OK,
-Motif de recours médico secouriste,$.qualification.healthMotive,1.9,M24.29,Hémorragie extériorisée - Epistaxis stoppée par compression,2.3,M09.02.05,Epistaxis stoppée par compression,OK,OK,
-Motif de recours médico secouriste,$.qualification.healthMotive,1.9,M24.91,Saignements bénins,2.3,M09.03.00,Saignements bénins,OK,OK,
-Motif de recours médico secouriste,$.qualification.healthMotive,1.9,M24.92,Saignements bénins - Saignement sans signe de gravité identifié,2.3,M09.03.01,Saignement bénin sans signe de gravité identifié,OK,OK,
-Motif de recours médico secouriste,$.qualification.healthMotive,1.9,M30.00,Circulatoire,2.3,M10.00.00,Problème circulatoire,OK,OK,
-Motif de recours médico secouriste,$.qualification.healthMotive,1.9,M30.61,Palpitations,2.3,M10.01.00,Palpitations,OK,OK,
-Motif de recours médico secouriste,$.qualification.healthMotive,1.9,M30.91,Autres troubles,2.3,M10.02.00,Autres troubles circulatoires,OK,OK,
-Motif de recours médico secouriste,$.qualification.healthMotive,1.9,M30.92,Autres troubles - Victime déjà choquée par un DAI,2.3,M10.02.01,Patient/victime choquée par défibrillateur implanté,OK,OK,
-Motif de recours médico secouriste,$.qualification.healthMotive,1.9,M30.93,Autres troubles - Fréquence cardiaque < 50 ou > 150,2.3,M10.02.02,Bradycardie < 50 ou tachycardie > 150,OK,OK,
-Motif de recours médico secouriste,$.qualification.healthMotive,1.9,M30.95,Autres troubles - Tension artérielle < 90 mm Hg,2.3,M10.02.03,Pression Artérielle < 90 mmHg,OK,OK,
-Motif de recours médico secouriste,$.qualification.healthMotive,1.9,M30.96,Autres troubles - Tension artérielle > 160 mm Hg,2.3,M10.02.04,Pression Artérielle > 160 mmHg,OK,OK,
-Motif de recours médico secouriste,$.qualification.healthMotive,1.9,M30.97,Autres troubles - Autre trouble sans signe de gravité identifié,2.3,M10.02.05,Autre trouble sans signe de gravité,OK,OK,
-Motif de recours médico secouriste,$.qualification.healthMotive,1.9,M31.00,Respiration,2.3,M11.00.00,Problème respiratoire,OK,OK,
-Motif de recours médico secouriste,$.qualification.healthMotive,1.9,M31.01,Détresse respiratoire,2.3,M11.01.00,Détresse respiratoire,OK,OK,
-Motif de recours médico secouriste,$.qualification.healthMotive,1.9,M31.02,"Détresse respiratoire - Etat asphyxique (moins de 4 syllabes ou mots courts, cyanose), ou obstruction complète",2.3,M11.01.01,Détresse respiratoire avec asphyxie,OK,OK,
-Motif de recours médico secouriste,$.qualification.healthMotive,1.9,M31.03,Détresse respiratoire - Epuisement respiratoire chez un nourrisson ou signes de lutte,2.3,M11.01.02,Epuisement respiratoire chez un nourrisson ,OK,OK,
-Motif de recours médico secouriste,$.qualification.healthMotive,1.9,M31.11,Difficultés respiratoires,2.3,M11.02.00,Difficultés respiratoires,OK,OK,
-Motif de recours médico secouriste,$.qualification.healthMotive,1.9,M31.12,Difficultés respiratoires - Respiration bruyante,2.3,M11.02.01,Respiration bruyante,OK,OK,
-Motif de recours médico secouriste,$.qualification.healthMotive,1.9,M31.13,Difficultés respiratoires - Sueurs et/ou troubles de conscience,2.3,M11.02.02,Difficultés respiratoires avec sueurs ou altération de conscience,OK,OK,
-Motif de recours médico secouriste,$.qualification.healthMotive,1.9,M31.19,Difficultés respiratoires - Difficultés respiratoires sans signe de gravité identifié,2.3,M11.02.03,Difficultés respiratoires sans signe de gravité,OK,OK,
-Motif de recours médico secouriste,$.qualification.healthMotive,1.9,M31.91,Autres problème respiratoire,2.3,M11.03.00,Autre problème respiratoire ,OK,OK,
-Motif de recours médico secouriste,$.qualification.healthMotive,1.9,M31.92,Autres problème respiratoire - Problème isolé d appareillage respiratoire ou canule,2.3,M11.03.01,Problème isolé d'appareillage respiratoire ou canule ,OK,OK,
-Motif de recours médico secouriste,$.qualification.healthMotive,1.9,M31.93,Autres problème respiratoire - Corps étranger expulsé,2.3,M11.03.02,Corps étranger expulsé des poumons,OK,OK,
-Motif de recours médico secouriste,$.qualification.healthMotive,1.9,M31.94,Autres problème respiratoire - Obstruction partielle,2.3,M11.03.03,Problème respiratoire avec obstruction partielle,OK,OK,
-Motif de recours médico secouriste,$.qualification.healthMotive,1.9,M31.99,Autres problème respiratoire - Autres problème respiratoire sans signe de gravité identifié,2.3,M11.03.04,Autre problème respiratoire sans signe de gravité,OK,OK,
-Motif de recours médico secouriste,$.qualification.healthMotive,1.9,M32.00,Neurologie,2.3,M12.00.00,Problème neurologique,OK,OK,
-Motif de recours médico secouriste,$.qualification.healthMotive,1.9,M32.01,Suspicion AVC / AIT,2.3,M12.01.00,Suspicion AVC / AIT,OK,OK,
-Motif de recours médico secouriste,$.qualification.healthMotive,1.9,M32.02,Suspicion AVC / AIT - Avec troubles de la conscience,2.3,M12.01.01,Suspicion AVC / AIT avec trouble de conscience ,OK,OK,
-Motif de recours médico secouriste,$.qualification.healthMotive,1.9,M32.03,Suspicion AVC / AIT - Avec céphalées ou vomissements,2.3,M12.01.00,Suspicion AVC / AIT,OK,OK,
-Motif de recours médico secouriste,$.qualification.healthMotive,1.9,M32.04,Suspicion AVC / AIT - Sans céphalée ou vomissement ni trouble de la conscience,2.3,M12.01.02,Suspicion AVC / AIT sans céphalée ou vomissement ni trouble de la conscience,OK,OK,
-Motif de recours médico secouriste,$.qualification.healthMotive,1.9,M32.05,Suspicion AVC / AIT - Avec disparition des signes associés à l‘AVC au moment de l‘appel,2.3,M12.01.03,Suspicion AVC / AIT avec disparition des signes d'AVC à l'appel,OK,OK,
-Motif de recours médico secouriste,$.qualification.healthMotive,1.9,M32.11,Convulsions persistantes,2.3,M12.02.00,Convulsions persistantes,OK,OK,
-Motif de recours médico secouriste,$.qualification.healthMotive,1.9,M32.21,Convulsions,2.3,M12.03.00,Convulsions ,OK,OK,
-Motif de recours médico secouriste,$.qualification.healthMotive,1.9,M32.22,Convulsions - Chez la femme enceinte,2.3,M12.03.01,Convulsions  - Chez la femme enceinte ,OK,OK,
-Motif de recours médico secouriste,$.qualification.healthMotive,1.9,M32.24,Convulsions - Réveil après convulsions,2.3,M12.03.03,En cours de réveil après convulsions,OK,OK,
-Motif de recours médico secouriste,$.qualification.healthMotive,1.9,M32.25,Convulsions - Hyperthermiques de l‘enfant,2.3,M12.03.02,Convulsions avec fièvre chez l'enfant,OK,OK,
-Motif de recours médico secouriste,$.qualification.healthMotive,1.9,M32.31,Trouble de la conscience,2.3,M12.04.00,Trouble de la conscience ,OK,OK,
-Motif de recours médico secouriste,$.qualification.healthMotive,1.9,M32.32,Trouble de la conscience - Chez le diabétique,2.3,M12.04.01,Trouble de la conscience chez un diabétique,OK,OK,
-Motif de recours médico secouriste,$.qualification.healthMotive,1.9,M32.34,Trouble de la conscience - Avec perte de connaissance initiale,2.3,M12.04.02,Trouble de la conscience avec perte de connaissance initiale,OK,OK,
-Motif de recours médico secouriste,$.qualification.healthMotive,1.9,M32.35,Trouble de la conscience - Somnolent et capable de parler ou de répondre à des ordres simples,2.3,M12.04.03,Somnolent et capable de parler ou de répondre à des ordres simples,OK,OK,
-Motif de recours médico secouriste,$.qualification.healthMotive,1.9,M32.36,"Trouble de la conscience - Confusion, désorientation",2.3,M12.04.04,"Confusion, désorientation",OK,OK,
-Motif de recours médico secouriste,$.qualification.healthMotive,1.9,M32.39,Trouble de la conscience - Trouble de la conscience sans signe de gravité identifié,2.3,M12.04.05,Autre trouble de la conscience sans signe de gravité,OK,OK,
-Motif de recours médico secouriste,$.qualification.healthMotive,1.9,M32.51,Malaise,2.3,M12.05.00,Malaise,OK,OK,
-Motif de recours médico secouriste,$.qualification.healthMotive,1.9,M32.52,Malaise - Malaise d effort,2.3,M12.05.02,Malaise au cours d'un effort,OK,OK,
-Motif de recours médico secouriste,$.qualification.healthMotive,1.9,M32.54,Malaise - Avec perte de connaissance initiale,2.3,M12.05.03,Malaise avec perte de connaissance initiale,OK,OK,
-Motif de recours médico secouriste,$.qualification.healthMotive,1.9,M32.55,Malaise - Avec trouble de la conscience,2.3,M12.05.04,Malaise avec trouble de la conscience,OK,OK,
-Motif de recours médico secouriste,$.qualification.healthMotive,1.9,M32.57,Malaise - Malaise sans signe de gravité identifié,2.3,M12.05.01,Malaise sans signe de gravité,OK,OK,
-Motif de recours médico secouriste,$.qualification.healthMotive,1.9,M32.91,Autre motif neurologique,2.3,M12.06.00,Autre motif neurologique ,OK,OK,
-Motif de recours médico secouriste,$.qualification.healthMotive,1.9,M32.92,Autre motif neurologique - Céphalées,2.3,M12.06.01,Céphalées isolées,OK,OK,
-Motif de recours médico secouriste,$.qualification.healthMotive,1.9,M32.95,Autre motif neurologique - Céphalées avec vomissement,2.3,M12.06.02,Céphalées avec vomissement,OK,OK,
-Motif de recours médico secouriste,$.qualification.healthMotive,1.9,M32.99,Autre motif neurologique - Autre motif neurologique sans signe de gravité identifié,2.3,M12.06.03,Autre motif neurologique sans signe de gravité,OK,OK,
-Motif de recours médico secouriste,$.qualification.healthMotive,1.9,M41.00,Traumatisme,2.3,M13.00.00,Traumatisme,OK,OK,
-Motif de recours médico secouriste,$.qualification.healthMotive,1.9,M41.01,Personne restant à terre suite à une chute,2.3,M13.01.00,Personne restant à terre suite à une chute,OK,OK,
-Motif de recours médico secouriste,$.qualification.healthMotive,1.9,M41.11,Suspicion de victime polytraumatisé,2.3,M13.02.00,Polytraumatisme / traumatisme sévère,OK,OK,
-Motif de recours médico secouriste,$.qualification.healthMotive,1.9,M41.21,Traumatisme tête - cou,2.3,M13.03.00,Traumatisme tête / cou,OK,OK,
-Motif de recours médico secouriste,$.qualification.healthMotive,1.9,M41.22,Traumatisme tête - cou - Avec perte de connaissance ou troubles de la la conscience,2.3,M13.03.01,Traumatisme tête / cou avec perte de connaissance initiale ou troubles de la conscience,OK,OK,
-Motif de recours médico secouriste,$.qualification.healthMotive,1.9,M41.29,Traumatisme tête - cou - Trauma tête / cou sans signe de gravité,2.3,M13.03.02,Traumatisme tête / cou sans signe de gravité,OK,OK,
-Motif de recours médico secouriste,$.qualification.healthMotive,1.9,M41.31,Traumatisme thorax,2.3,M13.04.00,Traumatisme thorax,OK,OK,
-Motif de recours médico secouriste,$.qualification.healthMotive,1.9,M41.32,Traumatisme thorax - Avec gêne respiratoire,2.3,M13.04.01,Traumatisme thorax avec gêne respiratoire,OK,OK,
-Motif de recours médico secouriste,$.qualification.healthMotive,1.9,M41.39,Traumatisme thorax - Traumatisme au thorax sans signe de gravité,2.3,M13.04.02,Traumatisme thorax sans signe de gravité,OK,OK,
-Motif de recours médico secouriste,$.qualification.healthMotive,1.9,M41.41,Traumatisme abdomen - bassin,2.3,M13.05.00,Traumatisme abdomen / bassin,OK,OK,
-Motif de recours médico secouriste,$.qualification.healthMotive,1.9,M41.42,Traumatisme abdomen - bassin - Choc violent,2.3,M13.05.01,Traumatisme abdomen / bassin violent,OK,OK,
-Motif de recours médico secouriste,$.qualification.healthMotive,1.9,M41.49,Traumatisme abdomen - bassin - Traumatisme abdomen - bassin sans signe de gravité,2.3,M13.05.02,Traumatisme abdomen / bassin sans signe de gravité,OK,OK,
-Motif de recours médico secouriste,$.qualification.healthMotive,1.9,M41.51,Traumatisme membres,2.3,M13.06.00,Traumatisme membres,OK,OK,
-Motif de recours médico secouriste,$.qualification.healthMotive,1.9,M41.52,Traumatisme membres - Amputation,2.3,M13.06.01,Traumatisme membre avec amputation,OK,OK,
-Motif de recours médico secouriste,$.qualification.healthMotive,1.9,M41.53,Traumatisme membres - Fracture ouverte,2.3,M13.06.02,Fracture ouverte de membre,OK,OK,
-Motif de recours médico secouriste,$.qualification.healthMotive,1.9,M41.54,Traumatisme membres - Fracture fermée,2.3,M13.06.03,Fracture fermée de membre,OK,OK,
-Motif de recours médico secouriste,$.qualification.healthMotive,1.9,M41.55,Traumatisme membres - déformation,2.3,M13.06.04,Traumatisme avec déformation de membre,OK,OK,
-Motif de recours médico secouriste,$.qualification.healthMotive,1.9,M41.59,Traumatisme membres - Traumatisme de membres sans signe de gravité,2.3,M13.06.05,Traumatisme de membres sans signe de gravité,OK,OK,
-Motif de recours médico secouriste,$.qualification.healthMotive,1.9,M41.61,Traumatisme doigts - orteils,2.3,M13.07.00,Traumatisme doigts - orteils,OK,OK,
-Motif de recours médico secouriste,$.qualification.healthMotive,1.9,M41.62,Traumatisme doigts - orteils - Amputation,2.3,M13.07.01,Traumatisme doigts / orteils avec amputation,OK,OK,
-Motif de recours médico secouriste,$.qualification.healthMotive,1.9,M41.64,Traumatisme doigts - orteils - Fracture ouverte,2.3,M13.07.02,Fracture ouverte de doigts / orteils ,OK,OK,
-Motif de recours médico secouriste,$.qualification.healthMotive,1.9,M41.65,Traumatisme doigts - orteils - Fracture fermée,2.3,M13.07.03,Fracture fermée doigts / orteils ,OK,OK,
-Motif de recours médico secouriste,$.qualification.healthMotive,1.9,M41.66,Traumatisme doigts - orteils - Déformation,2.3,M13.07.04,Traumatisme doigts / orteils  avec déformation,OK,OK,
-Motif de recours médico secouriste,$.qualification.healthMotive,1.9,M41.69,Traumatisme doigts - orteils - Traumatisme de doigt - orteil sans signe de gravité,2.3,M13.07.05,Traumatisme doigts / orteils  sans signe de gravité,OK,OK,
-Motif de recours médico secouriste,$.qualification.healthMotive,1.9,M45.00,Plaies,2.3,M14.00.00,Plaies,OK,OK,
-Motif de recours médico secouriste,$.qualification.healthMotive,1.9,M45.01,Pénétrante,2.3,M14.01.00,Plaie pénétrante,OK,OK,
-Motif de recours médico secouriste,$.qualification.healthMotive,1.9,M45.02,Etendue,2.3,M14.01.01,Plaie pénétrante étendue,OK,OK,
-Motif de recours médico secouriste,$.qualification.healthMotive,1.9,M45.03,Multiples,2.3,M14.01.02,Plaies pénétrantes multiples,OK,OK,
-Motif de recours médico secouriste,$.qualification.healthMotive,1.9,M45.05,Plaie grave du crâne (scalp),2.3,M14.01.03,Plaie grave du crâne (scalp),OK,OK,
-Motif de recours médico secouriste,$.qualification.healthMotive,1.9,M45.06,Plaie grave du visage,2.3,M14.01.04,Plaie grave du visage,OK,OK,
-Motif de recours médico secouriste,$.qualification.healthMotive,1.9,M45.07,Plaie grave du cou,2.3,M14.01.05,Plaie grave du cou,OK,OK,
-Motif de recours médico secouriste,$.qualification.healthMotive,1.9,M45.08,Plaie grave du thorax - abdomen,2.3,M14.01.06,Plaie grave du thorax - abdomen,OK,OK,
-Motif de recours médico secouriste,$.qualification.healthMotive,1.9,M45.09,"Pâleur, soif, prostation",2.3,M14.01.07,Plaie grave avec pâleur/soif/prostration,OK,OK,
-Motif de recours médico secouriste,$.qualification.healthMotive,1.9,M45.31,Morsure,2.3,M14.02.00,Morsure,OK,OK,
-Motif de recours médico secouriste,$.qualification.healthMotive,1.9,M45.32,Morsure - Morsure grave,2.3,M14.02.01,Morsure grave,OK,OK,
-Motif de recours médico secouriste,$.qualification.healthMotive,1.9,M45.33,Morsure - Morsure sans signe de gravité,2.3,M14.02.02,Morsure sans signe de gravité,OK,OK,
-Motif de recours médico secouriste,$.qualification.healthMotive,1.9,M46.00,Brûlures,2.3,M15.00.00,Brûlures,OK,OK,
-Motif de recours médico secouriste,$.qualification.healthMotive,1.9,M46.01,Brûlure thermique,2.3,M15.01.00,Brûlure thermique,OK,OK,
-Motif de recours médico secouriste,$.qualification.healthMotive,1.9,M46.02,Brûlure thermique - Brûlure étendue / circulaire ou tronc / face / cou,2.3,M15.01.01,Brûlure thermique grave (étendue / circulaire / tronc / face / cou),OK,OK,
-Motif de recours médico secouriste,$.qualification.healthMotive,1.9,M46.03,Brûlure thermique - Brûlure à l‘oeil,2.3,M15.01.02,Brûlure thermique à l'œil,OK,OK,
-Motif de recours médico secouriste,$.qualification.healthMotive,1.9,M46.09,Brûlure thermique - Brûlure thermique sans signe de gravité identifié,2.3,M15.01.03,Brûlure thermique sans signe de gravité,OK,OK,
-Motif de recours médico secouriste,$.qualification.healthMotive,1.9,M46.11,Brûlure chimique,2.3,M15.02.00,Brûlure chimique,OK,OK,
-Motif de recours médico secouriste,$.qualification.healthMotive,1.9,M46.12,Brûlure chimique - Brûlure étendue / circulaire ou tronc / face / cou,2.3,M15.02.01,Brûlure chimique grave (étendue / circulaire / tronc / face / cou),OK,OK,
-Motif de recours médico secouriste,$.qualification.healthMotive,1.9,M46.13,Brûlure chimique - Brûlure à l‘oeil,2.3,M15.02.02,Brûlure à l'œil,OK,OK,
-Motif de recours médico secouriste,$.qualification.healthMotive,1.9,M46.19,Brûlure chimique - Brûlure chimique sans signe de gravité identifié,2.3,M15.02.03,Brûlure chimique sans signe de gravité,OK,OK,
-Motif de recours médico secouriste,$.qualification.healthMotive,1.9,M46.21,Gelure,2.3,M15.03.00,Gelure,OK,OK,
-Motif de recours médico secouriste,$.qualification.healthMotive,1.9,M46.22,Gelure - Gelure grave,2.3,M15.03.01,Gelure grave,OK,OK,
-Motif de recours médico secouriste,$.qualification.healthMotive,1.9,M46.29,Gelure - Gelure sans signe de gravité identifié,2.3,M15.03.02,Gelure sans signe de gravité,OK,OK,
-Motif de recours médico secouriste,$.qualification.healthMotive,1.9,M50.00,Intoxication,2.3,M16.00.00,Intoxication,OK,OK,
-Motif de recours médico secouriste,$.qualification.healthMotive,1.9,M50.11,Intoxication au CO / fumées,2.3,M16.01.00,Intoxication au CO / fumées,OK,OK,
-Motif de recours médico secouriste,$.qualification.healthMotive,1.9,M50.12,Intoxication au CO / fumées - Avec convulsions / troubles de la conscience,2.3,M16.01.01,Intoxication au CO / fumées avec convulsions / troubles de la conscience,OK,OK,
-Motif de recours médico secouriste,$.qualification.healthMotive,1.9,M50.15,"Intoxication au CO / fumées - Vomissements, céphalées",2.3,M16.01.02,"Intoxication au CO / fumées avec vomissements, céphalées",OK,OK,
-Motif de recours médico secouriste,$.qualification.healthMotive,1.9,M50.16,Intoxication au CO / fumées - Sans signe de gravité identifié,2.3,M16.01.03,Intoxication au CO / fumées sans signe de gravité,OK,OK,
-Motif de recours médico secouriste,$.qualification.healthMotive,1.9,M50.21,Intoxication éthylique ou prise de stupéfiants,2.3,M16.02.00,Intoxication éthylique / prise de stupéfiants ,OK,OK,
-Motif de recours médico secouriste,$.qualification.healthMotive,1.9,M50.22,Intoxication éthylique ou prise de stupéfiants - Convulsions et/ou coma,2.3,M16.02.01,Intoxication éthylique / prise de stupéfiants avec convulsions ou coma,OK,OK,
-Motif de recours médico secouriste,$.qualification.healthMotive,1.9,M50.25,Intoxication éthylique ou prise de stupéfiants - Somnolence,2.3,M16.02.02,Intoxication éthylique / prise de stupéfiants avec somnolence,OK,OK,
-Motif de recours médico secouriste,$.qualification.healthMotive,1.9,M50.29,Intoxication éthylique ou prise de stupéfiants - Sans signe de gravité identifié,2.3,M16.02.03,Intoxication éthylique / prise de stupéfiants sans signe de gravité,OK,OK,
-Motif de recours médico secouriste,$.qualification.healthMotive,1.9,M50.31,Médicamenteuse,2.3,M16.03.00,Intoxication médicamenteuse ,OK,OK,
-Motif de recours médico secouriste,$.qualification.healthMotive,1.9,M50.32,Médicamenteuse - Convulsions et/ou coma,2.3,M16.03.01,Intoxication médicamenteuse avec convulsions ou coma,OK,OK,
-Motif de recours médico secouriste,$.qualification.healthMotive,1.9,M50.33,Médicamenteuse - Détresse respiratoire,2.3,M16.03.02,Intoxication médicamenteuse avec détresse respiratoire ,OK,OK,
-Motif de recours médico secouriste,$.qualification.healthMotive,1.9,M50.35,Médicamenteuse - Somnolence,2.3,M16.03.03,Intoxication médicamenteuse avec somnolence,OK,OK,
-Motif de recours médico secouriste,$.qualification.healthMotive,1.9,M50.39,Médicamenteuse - Sans signe de gravité identifié,2.3,M16.03.04,Intoxication médicamenteuse sans signe de gravité,OK,OK,
-Motif de recours médico secouriste,$.qualification.healthMotive,1.9,M50.51,Chimiques / venimeuses,2.3,M16.04.00,Intoxication chimique / venimeuse,OK,OK,
-Motif de recours médico secouriste,$.qualification.healthMotive,1.9,M50.52,Chimiques / venimeuses - Avec convulsions / troubles de la conscience,2.3,M16.04.01,Intoxication chimique / venimeuse avec convulsions / troubles de la conscience,OK,OK,
-Motif de recours médico secouriste,$.qualification.healthMotive,1.9,M50.53,Chimiques / venimeuses - Détresse respiratoire et/ou toux,2.3,M16.04.02,Intoxication chimique / venimeuse avec détresse respiratoire ou toux,OK,OK,
-Motif de recours médico secouriste,$.qualification.healthMotive,1.9,M50.54,Chimiques / venimeuses - Sans signe de gravité identifié,2.3,M16.04.03,Intoxication chimique / venimeuse sans signe de gravité,OK,OK,
-Motif de recours médico secouriste,$.qualification.healthMotive,1.9,M50.59,Douleurs ostéoarticulaires - Douleur ostéoarticulaire sans signe de gravité identifié,2.3,M17.04.02,Douleur ostéoarticulaire sans signe de gravité,OK,OK,
-Motif de recours médico secouriste,$.qualification.healthMotive,1.9,M60.00,Douleurs,2.3,M17.00.00,Douleurs,OK,OK,
-Motif de recours médico secouriste,$.qualification.healthMotive,1.9,M60.01,Céphalées,2.3,M17.01.00,Céphalées,OK,OK,
-Motif de recours médico secouriste,$.qualification.healthMotive,1.9,M60.03,Céphalées - Avec troubles de conscience,2.3,M17.01.01,Céphalées avec troubles de conscience,OK,OK,
-Motif de recours médico secouriste,$.qualification.healthMotive,1.9,M60.05,Céphalées - Céphalées chez la femme enceinte,2.3,M17.01.02,Céphalées chez la femme enceinte,OK,OK,
-Motif de recours médico secouriste,$.qualification.healthMotive,1.9,M60.08,Céphalées - Sans signe de gravité identifiée,2.3,M17.01.03,Céphalées sans signe de gravité,OK,OK,
-Motif de recours médico secouriste,$.qualification.healthMotive,1.9,M60.21,Douleurs abdominales,2.3,M17.02.00,Douleurs abdominales ,OK,OK,
-Motif de recours médico secouriste,$.qualification.healthMotive,1.9,M60.26,Douleurs abdominales - Sans signe de gravité identifiée,2.3,M17.02.01,Douleurs abdominales sans signe de gravité,OK,OK,
-Motif de recours médico secouriste,$.qualification.healthMotive,1.9,M60.31,Douleur thoracique,2.3,M17.03.00,Douleur thoracique ,OK,OK,
-Motif de recours médico secouriste,$.qualification.healthMotive,1.9,M60.32,Douleur thoracique - Avec antécédent infarctus et/ou même douleur,2.3,M17.03.00,Douleur thoracique ,OK,OK,
-Motif de recours médico secouriste,$.qualification.healthMotive,1.9,M60.33,Douleur thoracique - Douleur médiane en étau,2.3,M17.03.00,Douleur thoracique ,OK,OK,
-Motif de recours médico secouriste,$.qualification.healthMotive,1.9,M60.34,Douleur thoracique - Pendant effort ou dans les heures qui suivent,2.3,M17.03.00,Douleur thoracique ,OK,OK,
-Motif de recours médico secouriste,$.qualification.healthMotive,1.9,M60.35,Douleur thoracique - Facteurs de risque cardio-vasculaires,2.3,M17.03.00,Douleur thoracique ,OK,OK,
-Motif de recours médico secouriste,$.qualification.healthMotive,1.9,M60.36,Douleur thoracique - Pâleur intense,2.3,M17.03.00,Douleur thoracique ,OK,OK,
-Motif de recours médico secouriste,$.qualification.healthMotive,1.9,M60.37,Douleur thoracique - Sueurs,2.3,M17.03.00,Douleur thoracique ,OK,OK,
-Motif de recours médico secouriste,$.qualification.healthMotive,1.9,M60.38,Douleur thoracique - Nausées,2.3,M17.03.00,Douleur thoracique ,OK,OK,
-Motif de recours médico secouriste,$.qualification.healthMotive,1.9,M60.39,Douleur thoracique - Avec palpitations,2.3,M17.03.00,Douleur thoracique ,OK,OK,
-Motif de recours médico secouriste,$.qualification.healthMotive,1.9,M60.40,Douleur thoracique - Prise de toxiques récente,2.3,M17.03.00,Douleur thoracique ,OK,OK,
-Motif de recours médico secouriste,$.qualification.healthMotive,1.9,M60.41,Douleur thoracique - Douleur thoracique déclenchée par la toux ou la respiration,2.3,M17.03.00,Douleur thoracique ,OK,OK,
-Motif de recours médico secouriste,$.qualification.healthMotive,1.9,M60.49,Douleur thoracique - Douleur thoracique sans signe de gravité identifié,2.3,M17.03.00,Douleur thoracique ,OK,OK,
-Motif de recours médico secouriste,$.qualification.healthMotive,1.9,M60.51,Douleurs ostéoarticulaires,2.3,M17.04.00,Douleurs ostéoarticulaires ,OK,OK,
-Motif de recours médico secouriste,$.qualification.healthMotive,1.9,M60.53,Douleurs ostéoarticulaires - Douleur de membre,2.3,M17.04.01,Douleurs ostéoarticulaires ou de membre,OK,OK,
-Motif de recours médico secouriste,$.qualification.healthMotive,1.9,M60.91,Autres douleurs,2.3,M17.05.00,Autres douleurs ,OK,OK,
-Motif de recours médico secouriste,$.qualification.healthMotive,1.9,M60.92,Autres douleurs - Douleurs dentaires,2.3,M17.05.01,Douleurs dentaires,OK,OK,
-Motif de recours médico secouriste,$.qualification.healthMotive,1.9,M60.93,Autres douleurs - Douleurs oculaires,2.3,M17.05.02,Douleurs oculaires,OK,OK,
-Motif de recours médico secouriste,$.qualification.healthMotive,1.9,M60.94,"Autres douleurs - Douleurs ORL (nez, gorge, oreilles)",2.3,M17.05.03,Douleurs ORL (nez / gorge / oreilles),OK,OK,
-Motif de recours médico secouriste,$.qualification.healthMotive,1.9,M60.96,Autres douleurs - Sans signe de gravité identifié,2.3,M17.05.04,Autres douleurs sans signe de gravité,OK,OK,
-Motif de recours médico secouriste,$.qualification.healthMotive,1.9,M80.00,Accouchement / problème obstétrique,2.3,M18.00.00,Accouchement / problème obstétrique,OK,OK,
-Motif de recours médico secouriste,$.qualification.healthMotive,1.9,M80.01,Accouchement réalisé ou imminent,2.3,M18.01.00,Accouchement réalisé ou imminent,OK,OK,
-Motif de recours médico secouriste,$.qualification.healthMotive,1.9,M80.02,Accouchement réalisé ou imminent - Partie du bébé est visible,2.3,M18.01.01,Accouchement imminent avec bébé visible,OK,OK,
-Motif de recours médico secouriste,$.qualification.healthMotive,1.9,M80.03,Accouchement réalisé ou imminent - Accouchement réalisé,2.3,M18.01.02,Accouchement réalisé,OK,OK,
-Motif de recours médico secouriste,$.qualification.healthMotive,1.9,M80.04,Accouchement réalisé ou imminent - Sent le bébé descendre / Envie de pousser,2.3,M18.01.03,Accouchement imminent - Sent le bébé descendre ou envie de pousser,OK,OK,
-Motif de recours médico secouriste,$.qualification.healthMotive,1.9,M80.05,Accouchement réalisé ou imminent - Contractions < 5 min avec ou sans perte des eaux,2.3,M18.01.04,Accouchement imminent - Contractions < 5 min avec ou sans perte des eaux,OK,OK,
-Motif de recours médico secouriste,$.qualification.healthMotive,1.9,M80.06,Accouchement réalisé ou imminent - Contractions entre 5 et 10 min avec ou sans perte des eaux,2.3,M18.01.05,Accouchement imminent - Contractions entre 5 et 10 min avec ou sans perte des eaux,OK,OK,
-Motif de recours médico secouriste,$.qualification.healthMotive,1.9,M80.07,Accouchement réalisé ou imminent - Perte des eaux,2.3,M18.01.06,Accouchement imminent - Perte des eaux,OK,OK,
-Motif de recours médico secouriste,$.qualification.healthMotive,1.9,M80.08,Accouchement réalisé ou imminent - Contractions et hémorrgies,2.3,M18.01.07,Accouchement imminent - Contractions et hémorragies,OK,OK,
-Motif de recours médico secouriste,$.qualification.healthMotive,1.9,M80.11,Autre problème obstétrical,2.3,M18.02.00,Autre problème obstétrical ,OK,OK,
-Motif de recours médico secouriste,$.qualification.healthMotive,1.9,M80.12,Autre problème obstétrical - Saignement / hémorragie pour une grossesse,2.3,M18.02.01,Saignement / hémorragie au décours d'une grossesse,OK,OK,
-Motif de recours médico secouriste,$.qualification.healthMotive,1.9,M80.13,Autre problème obstétrical - Douleurs abdominales de la femme enceinte,2.3,M18.02.02,Douleurs abdominales chez une femme enceinte,OK,OK,
-Motif de recours médico secouriste,$.qualification.healthMotive,1.9,M80.14,Autre problème obstétrical - Saignement / hémorragie,2.3,M18.02.03,Autre problème obstétrical  avec saignement / hémorragie ,OK,OK,
-Motif de recours médico secouriste,$.qualification.healthMotive,1.9,M80.15,Autre problème obstétrical - Anomalie de résultat biologique,2.3,M18.02.04,Problème obstétrical avec anomalie de résultat biologique,OK,OK,
-Motif de recours médico secouriste,$.qualification.healthMotive,1.9,M80.19,Autre problème obstétrical - Autre problème obstétrical sans signe de gravité identifié,2.3,M18.02.05, Autre problème obstétrical sans signe de gravité,OK,OK,
-Motif de recours médico secouriste,$.qualification.healthMotive,1.9,M90.00,Autres affections,2.3,M19.00.00,Autres affections,OK,OK,
-Motif de recours médico secouriste,$.qualification.healthMotive,1.9,M90.01,Accident exposition aux risques biologiques,2.3,M19.01.00,Accident exposition aux risques biologiques,OK,OK,
-Motif de recours médico secouriste,$.qualification.healthMotive,1.9,M90.11,Allergies,2.3,M19.02.00,Allergies,OK,OK,
-Motif de recours médico secouriste,$.qualification.healthMotive,1.9,M90.12,"Allergies - Avec gonflement du visage, du cou, modification de la voix",2.3,M19.02.01,"Allergies avec gonflement du visage, du cou ou modification de la voix",OK,OK,
-Motif de recours médico secouriste,$.qualification.healthMotive,1.9,M90.13,Allergies - Avec sensation de malaise/problème digestif,2.3,M19.02.02,Allergies - Avec sensation de malaise/problème digestif,OK,OK,
-Motif de recours médico secouriste,$.qualification.healthMotive,1.9,M90.14,Allergies - Avec éruption généralisée,2.3,M19.02.03,Allergies avec éruption généralisée,OK,OK,
-Motif de recours médico secouriste,$.qualification.healthMotive,1.9,M90.16,Allergies - Avec perte de connaissance initiale ou inconscience,2.3,M19.02.04,Allergies  avec perte de connaissance initiale ou altération de la inconscience,OK,OK,
-Motif de recours médico secouriste,$.qualification.healthMotive,1.9,M90.17,Allergies - Avec difficultés respiratoires,2.3,M19.02.05,Allergies avec difficultés respiratoires,OK,OK,
-Motif de recours médico secouriste,$.qualification.healthMotive,1.9,M90.19,Allergies - Allergie sans signe de gravité identifié,2.3,M19.02.06,Allergies sans signe de gravité,OK,OK,
-Motif de recours médico secouriste,$.qualification.healthMotive,1.9,M90.21,Anomalie de la glycémie,2.3,M19.03.00,Anomalie de la glycémie,OK,OK,
-Motif de recours médico secouriste,$.qualification.healthMotive,1.9,M90.31,Demande de conseil médical ou ordonnance,2.3,M19.04.00,Demande de conseil médical ou ordonnance,OK,OK,
-Motif de recours médico secouriste,$.qualification.healthMotive,1.9,M90.41,Fièvre,2.3,M19.05.00,Fièvre,OK,OK,
-Motif de recours médico secouriste,$.qualification.healthMotive,1.9,M90.51,Trouble digestif,2.3,M19.06.00,Trouble digestif,OK,OK,
-Motif de recours médico secouriste,$.qualification.healthMotive,1.9,M90.52,Trouble digestif - Avec hémorragie digestive,2.3,M19.06.01,Trouble digestif avec hémorragie digestive,OK,OK,
-Motif de recours médico secouriste,$.qualification.healthMotive,1.9,M90.53,Trouble digestif - Avec trouble digestif,2.3,M19.06.02,Trouble digestif avec trouble du transit (diarrhée / vomissement),OK,OK,
-Motif de recours médico secouriste,$.qualification.healthMotive,1.9,M90.54,Trouble digestif - Problème de poche digestive,2.3,M19.06.03,Problème de poche digestive,OK,OK,
-Motif de recours médico secouriste,$.qualification.healthMotive,1.9,M90.55,Trouble digestif - Sans douleur,2.3,M19.06.04,Trouble digestif sans douleur,OK,OK,
-Motif de recours médico secouriste,$.qualification.healthMotive,1.9,M90.59,Trouble digestif - Troubles digestifs sans signe de gravité identifié,2.3,M19.06.05,Troubles digestifs sans signe de gravité,OK,OK,
-Motif de recours médico secouriste,$.qualification.healthMotive,1.9,M90.61,Problème psychiatrique / social,2.3,M19.07.00,Problème psychiatrique / social,OK,OK,
-Motif de recours médico secouriste,$.qualification.healthMotive,1.9,M90.62,Problème psychiatrique / social - Altération de l‘état général - misère physiologique et incurie,2.3,M19.07.01,Misère physiologique ou incurie,OK,OK,
-Motif de recours médico secouriste,$.qualification.healthMotive,1.9,M90.63,"Problème psychiatrique / social - Agitation, crise nerveuse, comportement violent",2.3,M19.07.02,Agitation / crise nerveuse / comportement violent,OK,OK,
-Motif de recours médico secouriste,$.qualification.healthMotive,1.9,M90.64,Problème psychiatrique / social - Etat de manque - Sevrage,2.3,M19.07.03,Etat de manque / Sevrage,OK,OK,
-Motif de recours médico secouriste,$.qualification.healthMotive,1.9,M90.65,Problème psychiatrique / social - Problème social ou sanitaire,2.3,M19.07.04,Problème social ou sanitaire,OK,OK,
-Motif de recours médico secouriste,$.qualification.healthMotive,1.9,M90.71,Problème infectieux,2.3,M19.08.00,Problème infectieux,OK,OK,
-Motif de recours médico secouriste,$.qualification.healthMotive,1.9,M98.00,Décès certain,2.3,M20.00.00,Décès certain,OK,OK,
-Motif de recours médico secouriste,$.qualification.healthMotive,1.9,M98.01,Corps en décomposition,2.3,M20.01.00,Corps en décomposition,OK,OK,
-Motif de recours médico secouriste,$.qualification.healthMotive,1.9,M98.11,Décés déclaré par un professionnel de santé,2.3,M20.02.00,Décés déclaré par un professionnel de santé,OK,OK,
-Motif de recours médico secouriste,$.qualification.healthMotive,1.9,M98.21,Rigidité cadavérique certaine au niveau des membres et corps froid,2.3,M20.03.00,Rigidité cadavérique et corps froid,OK,OK,
-Motif de recours médico secouriste,$.qualification.healthMotive,1.9,M98.31,Tête détachée,2.3,M20.04.00,Tête séparée du tronc,OK,OK,
-Motif de recours médico secouriste,$.qualification.healthMotive,2.3,M08.00.00,Personne inconsciente ,1.9,M22.00,Personne inconsciente,OK,OK,
-Motif de recours médico secouriste,$.qualification.healthMotive,2.3,M08.01.00,Personne en arrêt ventilatoire,1.9,M22.01,Pas de mouvement ventilatoire,OK,OK,
-Motif de recours médico secouriste,$.qualification.healthMotive,2.3,M08.02.00,Personne en arrêt cardio-respiratoire,1.9,M22.11,Arrêt cardio-respiratoire,OK,OK,
-Motif de recours médico secouriste,$.qualification.healthMotive,2.3,M08.03.00,Personne inconsciente qui respire,1.9,M22.21,Inconscient qui respire,OK,OK,
-Motif de recours médico secouriste,$.qualification.healthMotive,2.3,M09.00.00,Hémorragies / Saignements ,1.9,M24.00,Hémorragies / Saignements,OK,OK,
-Motif de recours médico secouriste,$.qualification.healthMotive,2.3,M09.01.00,Hémorragie ne pouvant être stoppée,1.9,M24.01,Hémorragie ne pouvant être stoppée,OK,OK,
-Motif de recours médico secouriste,$.qualification.healthMotive,2.3,M09.01.01,Epitaxis non stoppée par compression,1.9,M24.02,Hémorragie ne pouvant être stoppée - Epistaxis non stoppée par la compression,OK,OK,
-Motif de recours médico secouriste,$.qualification.healthMotive,2.3,M09.02.00,Hémorragie extériorisée,1.9,M24.21,Hémorragie extériorisée,OK,OK,
-Motif de recours médico secouriste,$.qualification.healthMotive,2.3,M09.02.01,Hémorragie digestive (haute ou basse) extériorisée,1.9,M24.25,Hémorragie extériorisée - Hémorragie digestive (haute ou basse),OK,OK,
-Motif de recours médico secouriste,$.qualification.healthMotive,2.3,M09.02.02,Hémorragie extériorisée avec malaise ,1.9,M24.26,Hémorragie extériorisée - Malaise,OK,OK,
-Motif de recours médico secouriste,$.qualification.healthMotive,2.3,M09.02.03,Crache du sang hémoptysie,1.9,M24.27,Hémorragie extériorisée - Crache du sang en toussant,OK,OK,
-Motif de recours médico secouriste,$.qualification.healthMotive,2.3,M09.02.04,Saignement stoppé par compression,1.9,M24.28,Hémorragie extériorisée - Saignement peut être stoppé par compression,OK,OK,
-Motif de recours médico secouriste,$.qualification.healthMotive,2.3,M09.02.05,Epistaxis stoppée par compression,1.9,M24.29,Hémorragie extériorisée - Epistaxis stoppée par compression,OK,OK,
-Motif de recours médico secouriste,$.qualification.healthMotive,2.3,M09.03.00,Saignements bénins,1.9,M24.91,Saignements bénins,OK,OK,
-Motif de recours médico secouriste,$.qualification.healthMotive,2.3,M09.03.01,Saignement bénin sans signe de gravité identifié,1.9,M24.92,Saignements bénins - Saignement sans signe de gravité identifié,OK,OK,
-Motif de recours médico secouriste,$.qualification.healthMotive,2.3,M10.00.00,Problème circulatoire,1.9,M30.00,Circulatoire,OK,OK,
-Motif de recours médico secouriste,$.qualification.healthMotive,2.3,M10.01.00,Palpitations,1.9,M30.61,Palpitations,OK,OK,
-Motif de recours médico secouriste,$.qualification.healthMotive,2.3,M10.02.00,Autres troubles circulatoires,1.9,M30.00,Circulatoire,OK,OK,
-Motif de recours médico secouriste,$.qualification.healthMotive,2.3,M10.02.01,Patient/victime choquée par défibrillateur implanté,1.9,M30.92,Autres troubles - Victime déjà choquée par un DAI,OK,OK,
-Motif de recours médico secouriste,$.qualification.healthMotive,2.3,M10.02.02,Bradycardie < 50 ou tachycardie > 150,1.9,M30.93,Autres troubles - Fréquence cardiaque < 50 ou > 150,OK,OK,
-Motif de recours médico secouriste,$.qualification.healthMotive,2.3,M10.02.03,Pression Artérielle < 90 mmHg,1.9,M30.95,Autres troubles - Tension artérielle < 90 mm Hg,OK,OK,
-Motif de recours médico secouriste,$.qualification.healthMotive,2.3,M10.02.04,Pression Artérielle > 160 mmHg,1.9,M30.96,Autres troubles - Tension artérielle > 160 mm Hg,OK,OK,
-Motif de recours médico secouriste,$.qualification.healthMotive,2.3,M10.02.05,Autre trouble sans signe de gravité,1.9,M30.97,Autres troubles - Autre trouble sans signe de gravité identifié,OK,OK,
-Motif de recours médico secouriste,$.qualification.healthMotive,2.3,M11.00.00,Problème respiratoire,1.9,M31.11 ,Difficultés respiratoires,OK,OK,
-Motif de recours médico secouriste,$.qualification.healthMotive,2.3,M11.01.00,Détresse respiratoire,1.9,M31.01,Détresse respiratoire,OK,OK,
-Motif de recours médico secouriste,$.qualification.healthMotive,2.3,M11.01.01,Détresse respiratoire avec asphyxie,1.9,M31.02,"Détresse respiratoire - Etat asphyxique (moins de 4 syllabes ou mots courts, cyanose), ou obstruction complète",OK,OK,
-Motif de recours médico secouriste,$.qualification.healthMotive,2.3,M11.01.02,Epuisement respiratoire chez un nourrisson ,1.9,M31.03,Détresse respiratoire - Epuisement respiratoire chez un nourrisson ou signes de lutte,OK,OK,
-Motif de recours médico secouriste,$.qualification.healthMotive,2.3,M11.02.00,Difficultés respiratoires,1.9,M31.11 ,Difficultés respiratoires,OK,OK,
-Motif de recours médico secouriste,$.qualification.healthMotive,2.3,M11.02.01,Respiration bruyante,1.9,M31.12,Difficultés respiratoires - Respiration bruyante,OK,OK,
-Motif de recours médico secouriste,$.qualification.healthMotive,2.3,M11.02.02,Difficultés respiratoires avec sueurs ou altération de conscience,1.9,M31.13,Difficultés respiratoires - Sueurs et/ou troubles de conscience,OK,OK,
-Motif de recours médico secouriste,$.qualification.healthMotive,2.3,M11.02.03,Difficultés respiratoires sans signe de gravité,1.9,M31.19,Difficultés respiratoires - Difficultés respiratoires sans signe de gravité identifié,OK,OK,
-Motif de recours médico secouriste,$.qualification.healthMotive,2.3,M11.03.00,Autres problèmes respiratoires,1.9,M31.91,Autres problème respiratoire,OK,OK,
-Motif de recours médico secouriste,$.qualification.healthMotive,2.3,M11.03.01,Problème isolé d'appareillage respiratoire ou canule ,1.9,M31.92,Autres problème respiratoire - Problème isolé d appareillage respiratoire ou canule,OK,OK,
-Motif de recours médico secouriste,$.qualification.healthMotive,2.3,M11.03.02,Corps étranger expulsé des poumons,1.9,M31.93,Autres problème respiratoire - Corps étranger expulsé,OK,OK,
-Motif de recours médico secouriste,$.qualification.healthMotive,2.3,M11.03.03,Problème respiratoire avec obstruction partielle,1.9,M31.94,Autres problème respiratoire - Obstruction partielle,OK,OK,
-Motif de recours médico secouriste,$.qualification.healthMotive,2.3,M11.03.04,Autres problème respiratoire sans signe de gravité,1.9,M31.99,Autres problème respiratoire - Autres problème respiratoire sans signe de gravité identifié,OK,OK,
-Motif de recours médico secouriste,$.qualification.healthMotive,2.3,M12.00.00,Problème neurologique,1.9,M32.00,Neurologie,OK,OK,
-Motif de recours médico secouriste,$.qualification.healthMotive,2.3,M12.01.00,Suspicion AVC / AIT,1.9,M32.01,Suspicion AVC / AIT,OK,OK,
-Motif de recours médico secouriste,$.qualification.healthMotive,2.3,M12.01.01,Suspicion AVC / AIT avec trouble de conscience ,1.9,M32.02,Suspicion AVC / AIT - Avec troubles de la conscience,OK,OK,
-Motif de recours médico secouriste,$.qualification.healthMotive,2.3,M12.01.02,Suspicion AVC / AIT sans céphalée ou vomissement ni trouble de la conscience,1.9,M32.01,Suspicion AVC / AIT,OK,OK,
-Motif de recours médico secouriste,$.qualification.healthMotive,2.3,M12.01.03,Suspicion AVC / AIT avec disparition des signes d'AVC à l'appel,1.9,M32.05,Suspicion AVC / AIT - Avec disparition des signes associés à l‘AVC au moment de l‘appel,OK,OK,
-Motif de recours médico secouriste,$.qualification.healthMotive,2.3,M12.02.00,Convulsions persistantes,1.9,M32.11,Convulsions persistantes,OK,OK,
-Motif de recours médico secouriste,$.qualification.healthMotive,2.3,M12.03.00,Convulsion ,1.9,M32.21,Convulsions,OK,OK,
-Motif de recours médico secouriste,$.qualification.healthMotive,2.3,M12.03.01,Convulsions chez une femme enceinte ,1.9,M32.22,Convulsions - Chez la femme enceinte,OK,OK,
-Motif de recours médico secouriste,$.qualification.healthMotive,2.3,M12.03.02,Convulsions avec fièvre chez l'enfant,1.9,M32.25,Convulsions - Hyperthermiques de l‘enfant,OK,OK,
-Motif de recours médico secouriste,$.qualification.healthMotive,2.3,M12.03.03,En cours de réveil après convulsions,1.9,M32.24,Convulsions - Réveil après convulsions,OK,OK,
-Motif de recours médico secouriste,$.qualification.healthMotive,2.3,M12.04.00,Trouble de la conscience ,1.9,M32.31,Trouble de la conscience,OK,OK,
-Motif de recours médico secouriste,$.qualification.healthMotive,2.3,M12.04.01,Trouble de la conscience chez un diabétique,1.9,M32.32,Trouble de la conscience - Chez le diabétique,OK,OK,
-Motif de recours médico secouriste,$.qualification.healthMotive,2.3,M12.04.02,Trouble de la conscience avec perte de connaissance initiale,1.9,M32.34,Trouble de la conscience - Avec perte de connaissance initiale,OK,OK,
-Motif de recours médico secouriste,$.qualification.healthMotive,2.3,M12.04.03,Somnolent et capable de parler ou de répondre à des ordres simples,1.9,M32.35,Trouble de la conscience - Somnolent et capable de parler ou de répondre à des ordres simples,OK,OK,
-Motif de recours médico secouriste,$.qualification.healthMotive,2.3,M12.04.04,"Confusion, désorientation",1.9,M32.36,"Trouble de la conscience - Confusion, désorientation",OK,OK,
-Motif de recours médico secouriste,$.qualification.healthMotive,2.3,M12.04.05,Autre trouble de la conscience sans signe de gravité,1.9,M32.39,Trouble de la conscience - Trouble de la conscience sans signe de gravité identifié,OK,OK,
-Motif de recours médico secouriste,$.qualification.healthMotive,2.3,M12.05.00,Malaise,1.9,M32.51,Malaise,OK,OK,
-Motif de recours médico secouriste,$.qualification.healthMotive,2.3,M12.05.01,Malaise sans signe de gravité,1.9,M32.57,Malaise - Malaise sans signe de gravité identifié,OK,OK,
-Motif de recours médico secouriste,$.qualification.healthMotive,2.3,M12.05.02,Malaise au cours d'un effort,1.9,M32.52,Malaise - Malaise d effort,OK,OK,
-Motif de recours médico secouriste,$.qualification.healthMotive,2.3,M12.05.03,Malaise avec perte de connaissance initiale,1.9,M32.54,Malaise - Avec perte de connaissance initiale,OK,OK,
-Motif de recours médico secouriste,$.qualification.healthMotive,2.3,M12.05.04,Malaise avec trouble de la conscience,1.9,M32.55,Malaise - Avec trouble de la conscience,OK,OK,
-Motif de recours médico secouriste,$.qualification.healthMotive,2.3,M12.06.00,Autre motif neurologique ,1.9,M32.91,Autre motif neurologique,OK,OK,
-Motif de recours médico secouriste,$.qualification.healthMotive,2.3,M12.06.01,Céphalées isolées,1.9,M32.92,Autre motif neurologique - Céphalées,OK,OK,
-Motif de recours médico secouriste,$.qualification.healthMotive,2.3,M12.06.02,Céphalées avec vomissement,1.9,M32.95,Autre motif neurologique - Céphalées avec vomissement,OK,OK,
-Motif de recours médico secouriste,$.qualification.healthMotive,2.3,M12.06.03,Autre motif neurologique sans signe de gravité,1.9,M32.99,Autre motif neurologique - Autre motif neurologique sans signe de gravité identifié,OK,OK,
-Motif de recours médico secouriste,$.qualification.healthMotive,2.3,M13.00.00,Traumatisme,1.9,M41.00,Traumatisme,OK,OK,
-Motif de recours médico secouriste,$.qualification.healthMotive,2.3,M13.01.00,Personne restant à terre suite à une chute,1.9,M41.01,Personne restant à terre suite à une chute,OK,OK,
-Motif de recours médico secouriste,$.qualification.healthMotive,2.3,M13.02.00,Polytraumatisme / traumatisme sévère,1.9,M41.11,Suspicion de victime polytraumatisé,OK,OK,
-Motif de recours médico secouriste,$.qualification.healthMotive,2.3,M13.03.00,Traumatisme tête / cou,1.9,M41.21,Traumatisme tête / cou,OK,OK,
-Motif de recours médico secouriste,$.qualification.healthMotive,2.3,M13.03.01,Traumatisme tête / cou avec perte de connaissance initiale ou troubles de la conscience,1.9,M41.22,Traumatisme tête - cou - Avec perte de connaissance ou troubles de la la conscience,OK,OK,
-Motif de recours médico secouriste,$.qualification.healthMotive,2.3,M13.03.02,Traumatisme tête / cou sans signe de gravité,1.9,M41.29,Traumatisme tête - cou - Trauma tête / cou sans signe de gravité,OK,OK,
-Motif de recours médico secouriste,$.qualification.healthMotive,2.3,M13.04.00,Traumatisme thorax,1.9,M41.31,Traumatisme thorax,OK,OK,
-Motif de recours médico secouriste,$.qualification.healthMotive,2.3,M13.04.01,Traumatisme thorax avec gêne respiratoire,1.9,M41.32,Traumatisme thorax avec gêne respiratoire,OK,OK,
-Motif de recours médico secouriste,$.qualification.healthMotive,2.3,M13.04.02,Traumatisme thorax sans signe de gravité,1.9,M41.39,Traumatisme thorax sans signe de gravité,OK,OK,
-Motif de recours médico secouriste,$.qualification.healthMotive,2.3,M13.05.00,Traumatisme abdomen / bassin,1.9,M41.32,Traumatisme abdomen / bassin,OK,OK,
-Motif de recours médico secouriste,$.qualification.healthMotive,2.3,M13.05.01,Traumatisme abdomen / bassin violent,1.9,M41.42,Traumatisme abdomen / bassin violent,OK,OK,
-Motif de recours médico secouriste,$.qualification.healthMotive,2.3,M13.05.02,Traumatisme abdomen / bassin sans signe de gravité,1.9,M41.49,Traumatisme abdomen / bassin sans signe de gravité,OK,OK,
-Motif de recours médico secouriste,$.qualification.healthMotive,2.3,M13.06.00,Traumatisme membres,1.9,M41.51,Traumatisme membres,OK,OK,
-Motif de recours médico secouriste,$.qualification.healthMotive,2.3,M13.06.01,Traumatisme membre avec amputation,1.9,M41.52,Traumatisme membre avec amputation,OK,OK,
-Motif de recours médico secouriste,$.qualification.healthMotive,2.3,M13.06.02,Fracture ouverte de membre,1.9,M41.53,Fracture ouverte de membre,OK,OK,
-Motif de recours médico secouriste,$.qualification.healthMotive,2.3,M13.06.03,Fracture fermée de membre,1.9,M41.54,Fracture fermée de membre,OK,OK,
-Motif de recours médico secouriste,$.qualification.healthMotive,2.3,M13.06.04,Traumatisme avec déformation de membre,1.9,M41.55,Traumatisme membres - déformation,OK,OK,
-Motif de recours médico secouriste,$.qualification.healthMotive,2.3,M13.06.05,Traumatisme de membres sans signe de gravité,1.9,M41.59,Traumatisme membres - Traumatisme de membres sans signe de gravité,OK,OK,
-Motif de recours médico secouriste,$.qualification.healthMotive,2.3,M13.07.00,Traumatisme doigts - orteils,1.9,M41.61,Traumatisme doigts - orteils,OK,OK,
-Motif de recours médico secouriste,$.qualification.healthMotive,2.3,M13.07.01,Traumatisme doigts / orteils avec amputation,1.9,M41.62,Traumatisme doigts - orteils - Amputation,OK,OK,
-Motif de recours médico secouriste,$.qualification.healthMotive,2.3,M13.07.02,Fracture ouverte de doigts / orteils ,1.9,M41.64,Traumatisme doigts - orteils - Fracture ouverte,OK,OK,
-Motif de recours médico secouriste,$.qualification.healthMotive,2.3,M13.07.03,Fracture fermée doigts / orteils ,1.9,M41.65,Traumatisme doigts - orteils - Fracture fermée,OK,OK,
-Motif de recours médico secouriste,$.qualification.healthMotive,2.3,M13.07.04,Traumatisme doigts / orteils  avec déformation,1.9,M41.66,Traumatisme doigts - orteils - Déformation,OK,OK,
-Motif de recours médico secouriste,$.qualification.healthMotive,2.3,M13.07.05,Traumatisme doigts / orteils  sans signe de gravité,1.9,M41.69,Traumatisme doigts - orteils - Traumatisme de doigt - orteil sans signe de gravité,OK,OK,
-Motif de recours médico secouriste,$.qualification.healthMotive,2.3,M14.00.00,Plaies,1.9,M45.00,Plaies,OK,OK,
-Motif de recours médico secouriste,$.qualification.healthMotive,2.3,M14.01.00,Plaie pénétrante,1.9,M45.01,Pénétrante,OK,OK,
-Motif de recours médico secouriste,$.qualification.healthMotive,2.3,M14.01.01,Plaie pénétrante étendue,1.9,M45.02,Etendue,OK,OK,
-Motif de recours médico secouriste,$.qualification.healthMotive,2.3,M14.01.02,Plaies pénétrantes multiples,1.9,M45.03,Multiples,OK,OK,
-Motif de recours médico secouriste,$.qualification.healthMotive,2.3,M14.01.03,Plaie grave du crâne (scalp),1.9,M45.05,Plaie grave du crâne (scalp),OK,OK,
-Motif de recours médico secouriste,$.qualification.healthMotive,2.3,M14.01.04,Plaie grave du visage,1.9,M45.06,Plaie grave du visage,OK,OK,
-Motif de recours médico secouriste,$.qualification.healthMotive,2.3,M14.01.05,Plaie grave du cou,1.9,M45.07,Plaie grave du cou,OK,OK,
-Motif de recours médico secouriste,$.qualification.healthMotive,2.3,M14.01.06,Plaie grave du thorax - abdomen,1.9,M45.08,Plaie grave du thorax - abdomen,OK,OK,
-Motif de recours médico secouriste,$.qualification.healthMotive,2.3,M14.01.07,Plaie grave avec pâleur/soif/prostration,1.9,M45.09,"Pâleur, soif, prostation",OK,OK,
-Motif de recours médico secouriste,$.qualification.healthMotive,2.3,M14.02.00,Morsure,1.9,M45.31,Morsure,OK,OK,
-Motif de recours médico secouriste,$.qualification.healthMotive,2.3,M14.02.01,Morsure grave,1.9,M45.32,Morsure - Morsure grave,OK,OK,
-Motif de recours médico secouriste,$.qualification.healthMotive,2.3,M14.02.02,Morsure sans signe de gravité,1.9,M45.33,Morsure - Morsure sans signe de gravité,OK,OK,
-Motif de recours médico secouriste,$.qualification.healthMotive,2.3,M15.00.00,Brûlures,1.9,M46.00,Brûlures,OK,OK,
-Motif de recours médico secouriste,$.qualification.healthMotive,2.3,M15.01.00,Brûlure thermique,1.9,M46.01,Brûlure thermique,OK,OK,
-Motif de recours médico secouriste,$.qualification.healthMotive,2.3,M15.01.01,Brûlure thermique grave (étendue / circulaire / tronc / face / cou),1.9,M46.02,Brûlure thermique - Brûlure étendue / circulaire ou tronc / face / cou,OK,OK,
-Motif de recours médico secouriste,$.qualification.healthMotive,2.3,M15.01.02,Brûlure thermique à l'œil,1.9,M46.03,Brûlure thermique - Brûlure à l‘oeil,OK,OK,
-Motif de recours médico secouriste,$.qualification.healthMotive,2.3,M15.01.03,Brûlure thermique sans signe de gravité,1.9,M46.09,Brûlure thermique - Brûlure thermique sans signe de gravité identifié,OK,OK,
-Motif de recours médico secouriste,$.qualification.healthMotive,2.3,M15.02.00,Brûlure chimique,1.9,M46.11,Brûlure chimique,OK,OK,
-Motif de recours médico secouriste,$.qualification.healthMotive,2.3,M15.02.01,Brûlure chimique grave (étendue / circulaire / tronc / face / cou),1.9,M46.12,Brûlure chimique - Brûlure étendue / circulaire ou tronc / face / cou,OK,OK,
-Motif de recours médico secouriste,$.qualification.healthMotive,2.3,M15.02.02,Brûlure à l'œil,1.9,M46.13,Brûlure chimique - Brûlure à l‘oeil,OK,OK,
-Motif de recours médico secouriste,$.qualification.healthMotive,2.3,M15.02.03,Brûlure chimique sans signe de gravité,1.9,M46.19,Brûlure chimique - Brûlure chimique sans signe de gravité identifié,OK,OK,
-Motif de recours médico secouriste,$.qualification.healthMotive,2.3,M15.03.00,Gelure,1.9,M46.21,Gelure,OK,OK,
-Motif de recours médico secouriste,$.qualification.healthMotive,2.3,M15.03.01,Gelure grave,1.9,M46.22,Gelure - Gelure grave,OK,OK,
-Motif de recours médico secouriste,$.qualification.healthMotive,2.3,M15.03.02,Gelure sans signe de gravité,1.9,M46.29,Gelure - Gelure sans signe de gravité identifié,OK,OK,
-Motif de recours médico secouriste,$.qualification.healthMotive,2.3,M16.00.00,Intoxication,1.9,M50.00,Intoxication,OK,OK,
-Motif de recours médico secouriste,$.qualification.healthMotive,2.3,M16.01.00,Intoxication au CO / fumées,1.9,M50.11,Intoxication au CO / fumées,OK,OK,
-Motif de recours médico secouriste,$.qualification.healthMotive,2.3,M16.01.01,Intoxication au CO / fumées avec convulsions / troubles de la conscience,1.9,M50.12,Intoxication au CO / fumées - Avec convulsions / troubles de la conscience,OK,OK,
-Motif de recours médico secouriste,$.qualification.healthMotive,2.3,M16.01.02,"Intoxication au CO / fumées avec vomissements, céphalées",1.9,M50.15,"Intoxication au CO / fumées - Vomissements, céphalées",OK,OK,
-Motif de recours médico secouriste,$.qualification.healthMotive,2.3,M16.01.03,Intoxication au CO / fumées sans signe de gravité,1.9,M50.16,Intoxication au CO / fumées - Sans signe de gravité identifié,OK,OK,
-Motif de recours médico secouriste,$.qualification.healthMotive,2.3,M16.02.00,Intoxication éthylique / prise de stupéfiants ,1.9,M50.21,Intoxication éthylique ou prise de stupéfiants,OK,OK,
-Motif de recours médico secouriste,$.qualification.healthMotive,2.3,M16.02.01,Intoxication éthylique / prise de stupéfiants avec convulsions ou coma,1.9,M50.22,Intoxication éthylique ou prise de stupéfiants - Convulsions et/ou coma,OK,OK,
-Motif de recours médico secouriste,$.qualification.healthMotive,2.3,M16.02.02,Intoxication éthylique / prise de stupéfiants avec somnolence,1.9,M50.25,Intoxication éthylique ou prise de stupéfiants - Somnolence,OK,OK,
-Motif de recours médico secouriste,$.qualification.healthMotive,2.3,M16.02.03,Intoxication éthylique / prise de stupéfiants sans signe de gravité,1.9,M50.29,Intoxication éthylique ou prise de stupéfiants - Sans signe de gravité identifié,OK,OK,
-Motif de recours médico secouriste,$.qualification.healthMotive,2.3,M16.03.00,Intoxication médicamenteuse ,1.9,M50.31,Médicamenteuse,OK,OK,
-Motif de recours médico secouriste,$.qualification.healthMotive,2.3,M16.03.01,Intoxication médicamenteuse avec convulsions ou coma,1.9,M50.32,Médicamenteuse - Convulsions et/ou coma,OK,OK,
-Motif de recours médico secouriste,$.qualification.healthMotive,2.3,M16.03.02,Intoxication médicamenteuse avec détresse respiratoire ,1.9,M50.33,Médicamenteuse - Détresse respiratoire,OK,OK,
-Motif de recours médico secouriste,$.qualification.healthMotive,2.3,M16.03.03,Intoxication médicamenteuse avec somnolence,1.9,M50.35,Médicamenteuse - Somnolence,OK,OK,
-Motif de recours médico secouriste,$.qualification.healthMotive,2.3,M16.03.04,Intoxication médicamenteuse sans signe de gravité,1.9,M50.39,Médicamenteuse - Sans signe de gravité identifié,OK,OK,
-Motif de recours médico secouriste,$.qualification.healthMotive,2.3,M16.04.00,Intoxication chimique / venimeuse,1.9,M50.51,Chimiques / venimeuses,OK,OK,
-Motif de recours médico secouriste,$.qualification.healthMotive,2.3,M16.04.01,Intoxication chimique / venimeuse avec convulsions / troubles de la conscience,1.9,M50.52,Chimiques / venimeuses - Avec convulsions / troubles de la conscience,OK,OK,
-Motif de recours médico secouriste,$.qualification.healthMotive,2.3,M16.04.02,Intoxication chimique / venimeuse avec détresse respiratoire ou toux,1.9,M50.53,Chimiques / venimeuses - Détresse respiratoire et/ou toux,OK,OK,
-Motif de recours médico secouriste,$.qualification.healthMotive,2.3,M16.04.03,Intoxication chimique / venimeuse sans signe de gravité,1.9,M50.54,Chimiques / venimeuses - Sans signe de gravité identifié,OK,OK,
-Motif de recours médico secouriste,$.qualification.healthMotive,2.3,M17.00.00,Douleurs,1.9,M60.00,Douleurs,OK,OK,
-Motif de recours médico secouriste,$.qualification.healthMotive,2.3,M17.01.00,Céphalées,1.9,M60.01,Céphalées,OK,OK,
-Motif de recours médico secouriste,$.qualification.healthMotive,2.3,M17.01.01,Céphalées avec troubles de conscience,1.9,M60.03,Céphalées - Avec troubles de conscience,OK,OK,
-Motif de recours médico secouriste,$.qualification.healthMotive,2.3,M17.01.02,Céphalées chez la femme enceinte,1.9,M60.05,Céphalées - Céphalées chez la femme enceinte,OK,OK,
-Motif de recours médico secouriste,$.qualification.healthMotive,2.3,M17.01.03,Céphalées sans signe de gravité,1.9,M60.08,Céphalées - Sans signe de gravité identifiée,OK,OK,
-Motif de recours médico secouriste,$.qualification.healthMotive,2.3,M17.02.00,Douleurs abdominales ,1.9,M60.21,Douleurs abdominales,OK,OK,
-Motif de recours médico secouriste,$.qualification.healthMotive,2.3,M17.02.01,Douleurs abdominales sans signe de gravité,1.9,M60.26,Douleurs abdominales - Sans signe de gravité identifiée,OK,OK,
-Motif de recours médico secouriste,$.qualification.healthMotive,2.3,M17.03.00,Douleur thoracique ,1.9,M60.31,Douleur thoracique,OK,OK,
-Motif de recours médico secouriste,$.qualification.healthMotive,2.3,M17.03.01,Douleur thoracique  -  cas d'usage n°1,1.9,M60.31,Douleur thoracique,OK,OK,
-Motif de recours médico secouriste,$.qualification.healthMotive,2.3,M17.03.02,Douleur thoracique  -  cas d'usage n°2,1.9,M60.31,Douleur thoracique,OK,OK,
-Motif de recours médico secouriste,$.qualification.healthMotive,2.3,M17.03.03,Douleur thoracique  - cas d'usage n°3,1.9,M60.31,Douleur thoracique,OK,OK,
-Motif de recours médico secouriste,$.qualification.healthMotive,2.3,M17.04.00,Douleurs ostéoarticulaires ,1.9,M60.51,Douleurs ostéoarticulaires,OK,OK,
-Motif de recours médico secouriste,$.qualification.healthMotive,2.3,M17.04.01,Douleurs ostéoarticulaires ou de membre,1.9,M60.53,Douleurs ostéoarticulaires - Douleur de membre,OK,OK,
-Motif de recours médico secouriste,$.qualification.healthMotive,2.3,M17.04.02,Douleur ostéoarticulaire sans signe de gravité,1.9,M50.59,Douleurs ostéoarticulaires - Douleur ostéoarticulaire sans signe de gravité identifié,OK,OK,
-Motif de recours médico secouriste,$.qualification.healthMotive,2.3,M17.05.00,Autres douleurs ,1.9,M60.91,Autres douleurs,OK,OK,
-Motif de recours médico secouriste,$.qualification.healthMotive,2.3,M17.05.01,Douleurs dentaires,1.9,M60.92,Autres douleurs - Douleurs dentaires,OK,OK,
-Motif de recours médico secouriste,$.qualification.healthMotive,2.3,M17.05.02,Douleurs oculaires,1.9,M60.93,Autres douleurs - Douleurs oculaires,OK,OK,
-Motif de recours médico secouriste,$.qualification.healthMotive,2.3,M17.05.03,Douleurs ORL (nez / gorge / oreilles),1.9,M60.94,"Autres douleurs - Douleurs ORL (nez, gorge, oreilles)",OK,OK,
-Motif de recours médico secouriste,$.qualification.healthMotive,2.3,M17.05.04,Autres douleurs sans signe de gravité,1.9,M60.96,Autres douleurs - Sans signe de gravité identifié,OK,OK,
-Motif de recours médico secouriste,$.qualification.healthMotive,2.3,M18.00.00,Accouchement / problème obstétrique,1.9,M80.00,Accouchement / problème obstétrique,OK,OK,
-Motif de recours médico secouriste,$.qualification.healthMotive,2.3,M18.01.00,Accouchement réalisé ou imminent,1.9,M80.01,Accouchement réalisé ou imminent,OK,OK,
-Motif de recours médico secouriste,$.qualification.healthMotive,2.3,M18.01.01,Accouchement imminent avec bébé visible,1.9,M80.02,Accouchement réalisé ou imminent - Partie du bébé est visible,OK,OK,
-Motif de recours médico secouriste,$.qualification.healthMotive,2.3,M18.01.02,Accouchement réalisé,1.9,M80.01,Accouchement réalisé ou imminent,OK,OK,
-Motif de recours médico secouriste,$.qualification.healthMotive,2.3,M18.01.03,Accouchement imminent - Sent le bébé descendre ou envie de pousser,1.9,M80.04,Accouchement réalisé ou imminent - Sent le bébé descendre / Envie de pousser,OK,OK,
-Motif de recours médico secouriste,$.qualification.healthMotive,2.3,M18.01.04,Accouchement imminent - Contractions < 5 min avec ou sans perte des eaux,1.9,M80.05,Accouchement réalisé ou imminent - Contractions < 5 min avec ou sans perte des eaux,OK,OK,
-Motif de recours médico secouriste,$.qualification.healthMotive,2.3,M18.01.05,Accouchement imminent - Contractions entre 5 et 10 min avec ou sans perte des eaux,1.9,M80.06,Accouchement réalisé ou imminent - Contractions entre 5 et 10 min avec ou sans perte des eaux,OK,OK,
-Motif de recours médico secouriste,$.qualification.healthMotive,2.3,M18.01.06,Accouchement imminent - Perte des eaux,1.9,M80.07,Accouchement réalisé ou imminent - Perte des eaux,OK,OK,
-Motif de recours médico secouriste,$.qualification.healthMotive,2.3,M18.01.07,Accouchement imminent - Contractions et hémorragies,1.9,M80.08,Accouchement réalisé ou imminent - Contractions et hémorrgies,OK,OK,
-Motif de recours médico secouriste,$.qualification.healthMotive,2.3,M18.02.00,Autre problème obstétrical ,1.9,M80.11,Autre problème obstétrical,OK,OK,
-Motif de recours médico secouriste,$.qualification.healthMotive,2.3,M18.02.01,Saignement / hémorragie au décours d'une grossesse,1.9,M80.12,Autre problème obstétrical - Saignement / hémorragie pour une grossesse,OK,OK,
-Motif de recours médico secouriste,$.qualification.healthMotive,2.3,M18.02.02,Douleurs abdominales chez une femme enceinte,1.9,M80.13,Autre problème obstétrical - Douleurs abdominales de la femme enceinte,OK,OK,
-Motif de recours médico secouriste,$.qualification.healthMotive,2.3,M18.02.03,Autre problème obstétrical  avec saignement / hémorragie ,1.9,M80.14,Autre problème obstétrical - Saignement / hémorragie,OK,OK,
-Motif de recours médico secouriste,$.qualification.healthMotive,2.3,M18.02.04,Problème obstétrical avec anomalie de résultat biologique,1.9,M80.15,Autre problème obstétrical - Anomalie de résultat biologique,OK,OK,
-Motif de recours médico secouriste,$.qualification.healthMotive,2.3,M18.02.05, Autre problème obstétrical sans signe de gravité,1.9,M80.19,Autre problème obstétrical - Autre problème obstétrical sans signe de gravité identifié,OK,OK,
-Motif de recours médico secouriste,$.qualification.healthMotive,2.3,M19.00.00,Autres affections,1.9,M90.00,Autres affections,OK,OK,
-Motif de recours médico secouriste,$.qualification.healthMotive,2.3,M19.01.00,Accident exposition aux risques biologiques,1.9,M90.01,Accident exposition aux risques biologiques,OK,OK,
-Motif de recours médico secouriste,$.qualification.healthMotive,2.3,M19.02.00,Allergies,1.9,M90.11,Allergies,OK,OK,
-Motif de recours médico secouriste,$.qualification.healthMotive,2.3,M19.02.01,"Allergies avec gonflement du visage, du cou ou modification de la voix",1.9,M90.12,"Allergies - Avec gonflement du visage, du cou, modification de la voix",OK,OK,
-Motif de recours médico secouriste,$.qualification.healthMotive,2.3,M19.02.02,Allergies avec sensation de malaise / problème digestif,1.9,M90.13,Allergies - Avec sensation de malaise/problème digestif,OK,OK,
-Motif de recours médico secouriste,$.qualification.healthMotive,2.3,M19.02.03,Allergies avec éruption généralisée,1.9,M90.14,Allergies - Avec éruption généralisée,OK,OK,
-Motif de recours médico secouriste,$.qualification.healthMotive,2.3,M19.02.04,Allergies  avec perte de connaissance initiale ou altération de la inconscience,1.9,M90.16,Allergies - Avec perte de connaissance initiale ou inconscience,OK,OK,
-Motif de recours médico secouriste,$.qualification.healthMotive,2.3,M19.02.05,Allergies avec difficultés respiratoires,1.9,M90.17,Allergies - Avec difficultés respiratoires,OK,OK,
-Motif de recours médico secouriste,$.qualification.healthMotive,2.3,M19.02.06,Allergies sans signe de gravité,1.9,M90.19,Allergies - Allergie sans signe de gravité identifié,OK,OK,
-Motif de recours médico secouriste,$.qualification.healthMotive,2.3,M19.03.00,Anomalie de la glycémie,1.9,M90.21,Anomalie de la glycémie,OK,OK,
-Motif de recours médico secouriste,$.qualification.healthMotive,2.3,M19.04.00,Demande de conseil médical ou ordonnance,1.9,M90.31,Demande de conseil médical ou ordonnance,OK,OK,
-Motif de recours médico secouriste,$.qualification.healthMotive,2.3,M19.05.00,Fièvre,1.9,M90.41,Fièvre,OK,OK,
-Motif de recours médico secouriste,$.qualification.healthMotive,2.3,M19.06.00,Trouble digestif,1.9,M90.51,Trouble digestif,OK,OK,
-Motif de recours médico secouriste,$.qualification.healthMotive,2.3,M19.06.01,Trouble digestif avec hémorragie digestive,1.9,M90.52,Trouble digestif - Avec hémorragie digestive,OK,OK,
-Motif de recours médico secouriste,$.qualification.healthMotive,2.3,M19.06.02,Trouble digestif avec trouble du transit (diarrhée / vomissement),1.9,M90.53,Trouble digestif - Avec trouble digestif,OK,OK,
-Motif de recours médico secouriste,$.qualification.healthMotive,2.3,M19.06.03,Problème de poche digestive,1.9,M90.54,Trouble digestif - Problème de poche digestive,OK,OK,
-Motif de recours médico secouriste,$.qualification.healthMotive,2.3,M19.06.04,Trouble digestif sans douleur,1.9,M90.55,Trouble digestif - Sans douleur,OK,OK,
-Motif de recours médico secouriste,$.qualification.healthMotive,2.3,M19.06.05,Troubles digestifs sans signe de gravité,1.9,M90.59,Trouble digestif - Troubles digestifs sans signe de gravité identifié,OK,OK,
-Motif de recours médico secouriste,$.qualification.healthMotive,2.3,M19.07.00,Problème psychiatrique / social,1.9,M90.61,Problème psychiatrique / social,OK,OK,
-Motif de recours médico secouriste,$.qualification.healthMotive,2.3,M19.07.01,Misère physiologique ou incurie,1.9,M90.62,Problème psychiatrique / social - Altération de l‘état général - misère physiologique et incurie,OK,OK,
-Motif de recours médico secouriste,$.qualification.healthMotive,2.3,M19.07.02,Agitation / crise nerveuse / comportement violent,1.9,M90.63,"Problème psychiatrique / social - Agitation, crise nerveuse, comportement violent",OK,OK,
-Motif de recours médico secouriste,$.qualification.healthMotive,2.3,M19.07.03,Etat de manque / Sevrage,1.9,M90.64,Problème psychiatrique / social - Etat de manque - Sevrage,OK,OK,
-Motif de recours médico secouriste,$.qualification.healthMotive,2.3,M19.07.04,Problème social ou sanitaire,1.9,M90.65,Problème psychiatrique / social - Problème social ou sanitaire,OK,OK,
-Motif de recours médico secouriste,$.qualification.healthMotive,2.3,M19.08.00,Problème infectieux,1.9,M90.71,Problème infectieux,OK,OK,
-Motif de recours médico secouriste,$.qualification.healthMotive,2.3,M20.00.00,Décès certain,1.9,M98.00,Décès certain,OK,OK,
-Motif de recours médico secouriste,$.qualification.healthMotive,2.3,M20.01.00,Corps en décomposition,1.9,M98.01,Corps en décomposition,OK,OK,
-Motif de recours médico secouriste,$.qualification.healthMotive,2.3,M20.02.00,Décés déclaré par un professionnel de santé,1.9,M98.11,Décés déclaré par un professionnel de santé,OK,OK,
-Motif de recours médico secouriste,$.qualification.healthMotive,2.3,M20.03.00,Rigidité cadavérique et corps froid,1.9,M98.21,Rigidité cadavérique certaine au niveau des membres et corps froid,OK,OK,
-Motif de recours médico secouriste,$.qualification.healthMotive,2.3,M20.04.00,Tête séparée du tronc,1.9,M98.31,Tête détachée,OK,OK,
-Risque menace et sensibilité,$.qualification.riskThreat,1.9,R36,"Discrimination raciale, religieuse, sexiste ou autre",2.3,,,OK,OK,A supprimmer (pas d'interet dans RMS)
-Risque menace et sensibilité,$.qualification.riskThreat,2.3,R17,Nuée d'insectes,1.9,R37,Situation instable/indéterminée,OK,OK,
-Risque menace et sensibilité,$.qualification.riskThreat,2.3,R18,Inondation,1.9,R37,Situation instable/indéterminée,OK,OK,
-Risque menace et sensibilité,$.qualification.riskThreat,2.3,R60,"Risque d'explosion, présence de gaz (bouteilles)",1.9,R13,"Risque d'explosion, présence de gaz",OK,OK,
-Risque menace et sensibilité,$.qualification.riskThreat,2.3,R61,Présence de matière ou matériel explosif,1.9,R13,"Risque d'explosion, présence de gaz",OK,OK,
-Risque menace et sensibilité,$.qualification.riskThreat,2.3,R62,GPL ou carburation non conventionnelle ,1.9,R13,"Risque d'explosion, présence de gaz",OK,OK,
-Risque menace et sensibilité,$.qualification.riskThreat,2.3,R63,Engin Propulsion / Traction électrique,1.9,R19,Risque électrique/ risque lié à une ligne HT ou THT,OK,OK,
-Risque menace et sensibilité,$.qualification.riskThreat,2.3,R64,Levée de doute ou sinistre naissant,1.9,R37,Situation instable/indéterminée,OK,OK,
-Risque menace et sensibilité,$.qualification.riskThreat,2.3,R65,Présence de bétail,1.9,R37,Situation instable/indéterminée,OK,OK,
-Risque menace et sensibilité,$.qualification.riskThreat,2.3,R66,Présence d'animal domestique,1.9,R37,Situation instable/indéterminée,OK,OK,
-Risque menace et sensibilité,$.qualification.riskThreat,2.3,R67,Porte/accès verrouillé,1.9,R37,Situation instable/indéterminée,OK,OK,
-Risque menace et sensibilité,$.qualification.riskThreat,2.3,R68,Patient / victime ejecté,1.9,R37,Situation instable/indéterminée,OK,OK,
-Risque menace et sensibilité,$.qualification.riskThreat,2.3,R69,Patient/Victime non visible,1.9,R37,Situation instable/indéterminée,OK,OK,
-Risque menace et sensibilité,$.qualification.riskThreat,2.3,R70,Carence prestataire extérieur,1.9,R37,Situation instable/indéterminée,OK,OK,
-Risque menace et sensibilité,$.qualification.riskThreat,2.3,R71,Situation en profondeur ,1.9,R37,Situation instable/indéterminée,OK,OK,
-Risque menace et sensibilité,$.qualification.riskThreat,2.3,R72,Hauteur inférieure ou égale à 2 étages ( <= 8mètres),1.9,R37,Situation instable/indéterminée,OK,OK,
-Risque menace et sensibilité,$.qualification.riskThreat,2.3,R73,Situation en milieu vicié,1.9,R37,Situation instable/indéterminée,OK,OK,
-Risque menace et sensibilité,$.qualification.riskThreat,2.3,R74,Locaux à sommeil,1.9,R37,Situation instable/indéterminée,OK,OK,
-Risque menace et sensibilité,$.qualification.riskThreat,2.3,R75,Gaz - Accident ou présence de travaux,1.9,R13,"Risque d'explosion, présence de gaz",OK,OK,
-Risque menace et sensibilité,$.qualification.riskThreat,2.3,R76,Gaz - Ouvrage endommagé visible,1.9,R13,"Risque d'explosion, présence de gaz",OK,OK,
-Risque menace et sensibilité,$.qualification.riskThreat,2.3,R77,Gaz - Ouvrage endommaé non visible,1.9,R13,"Risque d'explosion, présence de gaz",OK,OK,
-Risque menace et sensibilité,$.qualification.riskThreat,2.3,R78,Gaz - Dégâts apparents sur la conduite de gaz,1.9,R13,"Risque d'explosion, présence de gaz",OK,OK,
-Risque menace et sensibilité,$.qualification.riskThreat,2.3,R79,"Gaz - Bruits, sifflements, souffle, vibrations ou projections",1.9,R13,"Risque d'explosion, présence de gaz",OK,OK,
-Risque menace et sensibilité,$.qualification.riskThreat,2.3,R80,Gaz - Zone dense en population,1.9,R13,"Risque d'explosion, présence de gaz",OK,OK,
-Risque menace et sensibilité,$.qualification.riskThreat,2.3,R81,Gaz - Grand rassemblement de public,1.9,R13,"Risque d'explosion, présence de gaz",OK,OK,
-Risque menace et sensibilité,$.qualification.riskThreat,2.3,R82,Gaz - En sous-sol,1.9,R13,"Risque d'explosion, présence de gaz",OK,OK,
-Risque menace et sensibilité,$.qualification.riskThreat,2.3,R83,Nombreux appels,1.9,R37,Situation instable/indéterminée,OK,OK,
-Risque menace et sensibilité,$.qualification.riskThreat,2.3,R84,Hauteur supérieure à 2 étages (> 8 mètres),1.9,R37,Situation instable/indéterminée,OK,OK,
-Risque menace et sensibilité,$.qualification.riskThreat,2.3,R85,Hauteur supérieure à 7 étages (> 28 mètres),1.9,R37,Situation instable/indéterminée,OK,OK,
-Risque menace et sensibilité,$.qualification.riskThreat,2.3,R86,Voie non carrossable,1.9,R20,Difficulté d’accès sur site,OK,OK,
-Risque menace et sensibilité,$.qualification.riskThreat,2.3,R88,Victime face à un danger immédiat,1.9,R37,Situation instable/indéterminée,OK,OK,
-Risque menace et sensibilité,$.qualification.riskThreat,2.3,R89,Victime face à une menace plus ou moins différée,1.9,R37,Situation instable/indéterminée,OK,OK,
-Risque menace et sensibilité,$.qualification.riskThreat,2.3,R90,Présence dans un lieu public non protégé ,1.9,R37,Situation instable/indéterminée,OK,OK,
-Risque menace et sensibilité,$.qualification.riskThreat,2.3,R91,Implication d’une autorité,1.9,R25,Implication d’une personnalité,OK,OK,
-Type de lieu,$.qualification.locationKind,1.9,L02.02.04,Hôtel sur autoroute,2.3,L02.02.03,Aire de repos ou de service sur voie rapide,OK,OK,
-Type de lieu,$.qualification.locationKind,1.9,L02.03.03,Tunnel,2.3,L02.03.00,Voie ferrée/tramway/métro,OK,OK,
-Type de lieu,$.qualification.locationKind,1.9,L02.06.07,CRNA,2.3,L02.06.00,Aéroport / aérodrome,OK,OK,
-Type de lieu,$.qualification.locationKind,1.9,L02.06.08,PCZAR,2.3,L02.06.00,Aéroport / aérodrome,OK,OK,
-Type de lieu,$.qualification.locationKind,1.9,L03.04.00,"Lieu d’activité professionnelle collective, équipement lourds",2.3,L03.05.00,Autre local d’activité professionnelle,OK,OK,
-Type de lieu,$.qualification.locationKind,1.9,L04.07.01,A l’intérieur,2.3,L04.07.00,Établissement de santé,OK,OK,
-Type de lieu,$.qualification.locationKind,1.9,L04.07.02,A l’extérieur,2.3,L04.07.00,Établissement de santé,OK,OK,
-Type de lieu,$.qualification.locationKind,1.9,L05.01.02,Prairie,2.3,L05.01.01,Champ / prairie,OK,OK,
-Type de lieu,$.qualification.locationKind,1.9,L05.01.03,"Milieu forestier, broussailles",2.3,L05.01.03,Milieu forestier,OK,OK,
-Type de lieu,$.qualification.locationKind,1.9,L05.04.03,"Port, quai, embarcadère",2.3,L05.04.00,Milieu maritime,OK,OK,
-Type de lieu,$.qualification.locationKind,1.9,L07.01.00,Autre lieu d'intervention,2.3,L07.00.00,Lieu non explicite,OK,OK,
-Type de lieu,$.qualification.locationKind,1.9,L07.01.01,Site sensible,2.3,L07.00.00,Lieu non explicite,OK,OK,
-Type de lieu,$.qualification.locationKind,1.9,L07.02.00,Lieu indéterminé,2.3,L07.00.00,Lieu non explicite,OK,OK,
-Type de lieu,$.qualification.locationKind,2.3,L01.01.05,Toiture/Combles d'une maison,1.9,L01.01.00,"Maison particulière, pavillon",OK,OK,
-Type de lieu,$.qualification.locationKind,2.3,L01.02.13,Local poubelle / vide ordure de l'immeuble,1.9,L01.02.00,Lieu d'habitation collectif ou foyer d'hébergement,OK,OK,
-Type de lieu,$.qualification.locationKind,2.3,L01.02.14,Balcon/terrasse de l'immeuble,1.9,L01.02.00,Lieu d'habitation collectif ou foyer d'hébergement,OK,OK,
-Type de lieu,$.qualification.locationKind,2.3,L01.03.04,Campement,1.9,L01.03.00,Habitat spécifique,OK,OK,
-Type de lieu,$.qualification.locationKind,2.3,L01.03.05,Grande demeure / château / manoir,1.9,L01.03.00,Habitat spécifique,OK,OK,
-Type de lieu,$.qualification.locationKind,2.3,L01.03.06,Chaumière,1.9,L01.03.00,Habitat spécifique,OK,OK,
-Type de lieu,$.qualification.locationKind,2.3,L02.01.01,Tunnel sur voie publique (hors voie rapide),1.9,L02.02.05,Tunnel,OK,OK,
-Type de lieu,$.qualification.locationKind,2.3,L02.01.02,Piste cyclable,1.9,L02.01.00,Voie publique hors voie rapide,OK,OK,
-Type de lieu,$.qualification.locationKind,2.3,L02.01.03,Pont/viaduc sur voie publique (hors voie rapide),1.9,L02.01.00,Voie publique hors voie rapide,OK,OK,
-Type de lieu,$.qualification.locationKind,2.3,L02.02.06,Pont/viaduc sur voie rapide,1.9,L02.02.00,Voie rapide,OK,OK,
-Type de lieu,$.qualification.locationKind,2.3,L02.03.04,Pont/viaduc sur voie ferrée,1.9,L02.03.00,Voie ferrée,OK,OK,
-Type de lieu,$.qualification.locationKind,2.3,L02.03.05,Passage à niveau,1.9,L02.03.00,Voie ferrée,OK,OK,
-Type de lieu,$.qualification.locationKind,2.3,L02.04.01,Tunnel  (voie fluviale),1.9,L02.04.00,Voie fluviale,OK,OK,
-Type de lieu,$.qualification.locationKind,2.3,L02.04.02,Ecluse,1.9,L02.04.00,Voie fluviale,OK,OK,
-Type de lieu,$.qualification.locationKind,2.3,L02.06.09,Aéroport - Zone de sûreté à accès réglementé,1.9,L02.06.00,Aéroport / aérodrome,OK,OK,
-Type de lieu,$.qualification.locationKind,2.3,L02.06.10,Base ou enceinte aérienne militaire,1.9,L02.06.00,Aéroport / aérodrome,OK,OK,
-Type de lieu,$.qualification.locationKind,2.3,L02.07.04,Gare ou station souterraine,1.9,L02.07.00,Gare ferroviaire et routière,OK,OK,
-Type de lieu,$.qualification.locationKind,2.3,L02.07.05,Gare ou station aérienne,1.9,L02.07.00,Gare ferroviaire et routière,OK,OK,
-Type de lieu,$.qualification.locationKind,2.3,L02.07.06,Arrêt de bus / tramway,1.9,L02.07.00,Gare ferroviaire et routière,OK,OK,
-Type de lieu,$.qualification.locationKind,2.3,L02.07.07,Voies de circulation de la gare,1.9,L02.07.00,Gare ferroviaire et routière,OK,OK,
-Type de lieu,$.qualification.locationKind,2.3,L02.08.01,Pont hors aquatique,1.9,L02.01.00,Voie publique hors voie rapide,OK,OK,
-Type de lieu,$.qualification.locationKind,2.3,L02.08.02,Pont aquatique mer,1.9,L02.04.00,Voie fluviale,OK,OK,
-Type de lieu,$.qualification.locationKind,2.3,L02.08.03,Pont aquatique eaux intérieures,1.9,L02.04.00,Voie fluviale,OK,OK,
-Type de lieu,$.qualification.locationKind,2.3,L02.09.00,Port/Quai/Embarcadère,1.9,L02.04.00,Voie fluviale,OK,OK,
-Type de lieu,$.qualification.locationKind,2.3,L02.09.01,Port civil,1.9,L02.04.00,Voie fluviale,OK,OK,
-Type de lieu,$.qualification.locationKind,2.3,L02.09.02,Port militaire,1.9,L02.04.00,Voie fluviale,OK,OK,
-Type de lieu,$.qualification.locationKind,2.3,L03.02.01,Corps de ferme ,1.9,L03.02.00,Local agricole,OK,OK,
-Type de lieu,$.qualification.locationKind,2.3,L03.02.02,Hangar agricole ,1.9,L03.02.00,Local agricole,OK,OK,
-Type de lieu,$.qualification.locationKind,2.3,L04.06.06,Bibliothèque / médiathèque,1.9,L04.06.00,Espace évènementiel et/ou culturel,OK,OK,
-Type de lieu,$.qualification.locationKind,2.3,L04.07.04,Etablissement de santé spécialisé,1.9,L04.07.00,Établissement de santé,OK,OK,
-Type de lieu,$.qualification.locationKind,2.3,L04.07.05,Etablissement de santé (zone d'hospitalisation),1.9,L04.07.00,Établissement de santé,OK,OK,
-Type de lieu,$.qualification.locationKind,2.3,L04.07.06,Établissement de santé (hors zone d'hospitalisation),1.9,L04.07.00,Établissement de santé,OK,OK,
-Type de lieu,$.qualification.locationKind,2.3,L04.09.03,Autre établissement médico-social,1.9,L04.09.00,Établissement médico-social,OK,OK,
-Type de lieu,$.qualification.locationKind,2.3,L04.11.05,Autre enceinte sportive,1.9,L04.11.00,Enceinte sportive,OK,OK,
-Type de lieu,$.qualification.locationKind,2.3,L04.13.05,Centre de formation pour adulte,1.9,L04.13.00,Hébergement touristique,OK,OK,
-Type de lieu,$.qualification.locationKind,2.3,L05.01.05,Espace naturel péri-urbain,1.9,L05.01.00,Plaine et campagne,OK,OK,
-Type de lieu,$.qualification.locationKind,2.3,L05.01.03,Milieu forestier,1.9,L05.01.00,Plaine et campagne,OK,OK,
-Type de lieu,$.qualification.locationKind,2.3,L05.01.04,Sous-bois,1.9,L05.01.00,Plaine et campagne,OK,OK,
-Type de lieu,$.qualification.locationKind,2.3,L05.03.03,Eaux vives,1.9,L05.03.00,Milieu aquatique en eau douce,OK,OK,
-Type de lieu,$.qualification.locationKind,2.3,L05.03.04,Zone de baignade en eau douce réglementée,1.9,L05.03.00,Milieu aquatique en eau douce,OK,OK,
-Type de lieu,$.qualification.locationKind,2.3,L05.03.05,Plage / berge en eau douce,1.9,L05.03.00,Milieu aquatique en eau douce,OK,OK,
-Type de lieu,$.qualification.locationKind,2.3,L05.04.07,Estran,1.9,L05.04.00,Milieu maritime,OK,OK,
-Type de lieu,$.qualification.locationKind,2.3,L06.01.09,Lieu de stockage ou recyclage véhicules et engins divers,1.9,L06.01.00,Site industriel,OK,OK,
-Type de lieu,$.qualification.locationKind,2.3,L06.01.10,Site de construction naval,1.9,L06.01.00,Site industriel,OK,OK,
-Type de lieu,$.qualification.locationKind,2.3,L06.02.01,Ferme photovoltaïque,1.9,L06.02.00,Site de production transport d'énergie,OK,OK,
-Type de lieu,$.qualification.locationKind,2.3,L06.02.02,Parc éolien,1.9,L06.02.00,Site de production transport d'énergie,OK,OK,
-Type de lieu,$.qualification.locationKind,2.3,L06.02.03,Barrage hydraulique / retenue,1.9,L06.02.00,Site de production transport d'énergie,OK,OK,
-Type de lieu,$.qualification.locationKind,2.3,L06.02.04,Poste de transformation électrique,1.9,L06.02.00,Site de production transport d'énergie,OK,OK,
-Type de lieu,$.qualification.locationKind,2.3,L06.02.05,Ligne de transport d’électricité,1.9,L06.02.00,Site de production transport d'énergie,OK,OK,
-Type de lieu,$.qualification.locationKind,2.3,L06.02.06,Centrale Thermique (gaz / charbon / biomasse),1.9,L06.02.00,Site de production transport d'énergie,OK,OK,
-Type de lieu,$.qualification.locationKind,2.3,L06.02.07,Centre de méthanisation ,1.9,L06.02.00,Site de production transport d'énergie,OK,OK,
-Type de lieu,$.qualification.locationKind,2.3,L06.02.08,"Infrastructure de transport (Pipeline, Oléoduc, Gazoduc)",1.9,L06.02.00,Site de production transport d'énergie,OK,OK,
-Type de lieu,$.qualification.locationKind,2.3,L06.02.09,Poste de transformation gaz,1.9,L06.02.00,Site de production transport d'énergie,OK,OK,
-Type de lieu,$.qualification.locationKind,2.3,L06.06.05,Centre en-Route de la Navigation Aérienne,1.9,L06.06.00,Administration publique,OK,OK,
-Type de lieu,$.qualification.locationKind,2.3,L06.08.00,Station-service,1.9,L06.00.00,Zone ou site particulier,OK,OK,
-Type de lieu,$.qualification.locationKind,2.3,L06.09.00,Site comportant des animaux,1.9,L06.00.00,Zone ou site particulier,OK,OK,
-Type de lieu,$.qualification.locationKind,2.3,L06.09.01,Elevage d'animaux,1.9,L06.00.00,Zone ou site particulier,OK,OK,
-Type de lieu,$.qualification.locationKind,2.3,L06.09.02,Haras / centre équestre / écuries,1.9,L06.00.00,Zone ou site particulier,OK,OK,
-Type de lieu,$.qualification.locationKind,2.3,L06.09.03,Animalerie ou clinique vétérinaire,1.9,L06.00.00,Zone ou site particulier,OK,OK,
-Type de lieu,$.qualification.locationKind,2.3,L06.10.00,Décharge / casse automobile,1.9,L06.00.00,Zone ou site particulier,OK,OK,
+﻿Champ;Balise;Version code reçu;Code reçu;Libellé reçu;Version code transmis;Code à transmettre;Libellé à transmettre;VALIDATION ANSC;VALIDATION ANS;Observation;;;;;
+Circonstances Natures de Faits;$.qualification.whatsHappen;1.9;C02.05.03;Atteinte aux personnesPsychiatrique;2.3;C02.18.00;Problème psychiatrique, menace de suicide;OK;OK;;;;;;
+Circonstances Natures de Faits;$.qualification.whatsHappen;1.9;C02.16.02;Atteinte aux personnesAutre type d’atteinte aux personnes;2.3;C02.16.00;Autre atteinte aux personnes;OK;OK;;;;;;
+Circonstances Natures de Faits;$.qualification.whatsHappen;1.9;C04.07.00;Feu à l'air libre;2.3;C04.08.00;Autre type d’incendie;OK;OK;;;;;;
+Circonstances Natures de Faits;$.qualification.whatsHappen;1.9;C04.07.01;IncendieFeu de produits de classe A;2.3;C04.08.00;Autre type d’incendie;OK;OK;;;;;;
+Circonstances Natures de Faits;$.qualification.whatsHappen;1.9;C04.07.02;IncendieFeu de produits de classe B;2.3;C04.08.00;Autre type d’incendie;OK;OK;;;;;;
+Circonstances Natures de Faits;$.qualification.whatsHappen;1.9;C04.07.03;IncendieFeu de produits de classe C;2.3;C04.08.00;Autre type d’incendie;OK;OK;;;;;;
+Circonstances Natures de Faits;$.qualification.whatsHappen;1.9;C04.07.04;IncendieFeu de produits de classe D;2.3;C04.08.00;Autre type d’incendie;OK;OK;;;;;;
+Circonstances Natures de Faits;$.qualification.whatsHappen;1.9;C04.09.00;Alarme incendie;2.3;C11.01.01;Alarme incendie;OK;OK;;;;;;
+Circonstances Natures de Faits;$.qualification.whatsHappen;1.9;C07.03.00;Ordre public;2.3;C07.00.00;Ordre public;OK;OK;;;;;;
+Circonstances Natures de Faits;$.qualification.whatsHappen;1.9;C07.03.01;Ordre publicDifférend familial;2.3;C02.19.01;Différend familial;OK;OK;;;;;;
+Circonstances Natures de Faits;$.qualification.whatsHappen;1.9;C07.03.02;Ordre publicNon représentation d’enfant;2.3;C02.19.02;Non représentation d’enfant;OK;OK;;;;;;
+Circonstances Natures de Faits;$.qualification.whatsHappen;1.9;C07.03.03;Ordre publicDifférend de voisinage;2.3;C02.19.03;Différend de voisinage;OK;OK;;;;;;
+Circonstances Natures de Faits;$.qualification.whatsHappen;1.9;C07.03.04;Ordre publicAutres différends;2.3;C02.19.04;Autre différend;OK;OK;;;;;;
+Circonstances Natures de Faits;$.qualification.whatsHappen;1.9;C07.03.05;Ordre publicLitiges;2.3;C02.19.05;Litige;OK;OK;;;;;;
+Circonstances Natures de Faits;$.qualification.whatsHappen;1.9;C10.01.07;Disparitions et découvertesRecherche secours investigation;2.3;C10.01.00;Disparition ou découverte d’individu;OK;OK;;;;;;
+Circonstances Natures de Faits;$.qualification.whatsHappen;1.9;C10.02.00;Decouverte de cadavre;2.3;C02.17.00;Découverte de cadavre/mort suspecte;OK;OK;;;;;;
+Circonstances Natures de Faits;$.qualification.whatsHappen;1.9;C10.02.01;Disparitions et découvertesMort a priori suspecte;2.3;C02.17.01;Découverte de cadavre;OK;OK;;;;;;
+Circonstances Natures de Faits;$.qualification.whatsHappen;1.9;C10.02.02;Disparitions et découvertesMort a priori naturelle;2.3;C02.17.01;Découverte de cadavre;OK;OK;;;;;;
+Circonstances Natures de Faits;$.qualification.whatsHappen;2.3;C02.17.00;Découverte de cadavre/mort suspecte;1.9;C10.02.01;Mort suspecte;OK;OK;;;;;;
+Circonstances Natures de Faits;$.qualification.whatsHappen;2.3;C02.17.01;Découverte de cadavre;1.9;C10.02.01;Mort suspecte;OK;OK;;;;;;
+Circonstances Natures de Faits;$.qualification.whatsHappen;2.3;C02.17.02;Mort suspecte;1.9;C10.02.01;Mort suspecte;OK;OK;;;;;;
+Circonstances Natures de Faits;$.qualification.whatsHappen;2.3;C02.18.00;Problème psychiatrique, menace de suicide;1.9;C02.05.03;Psychiatrique;OK;OK;;;;;;
+Circonstances Natures de Faits;$.qualification.whatsHappen;2.3;C02.19.00;Différends et litiges inter-personnels;1.9;C07.03.00;Différends et litiges inter-personnels;OK;OK;;;;;;
+Circonstances Natures de Faits;$.qualification.whatsHappen;2.3;C02.19.01;Différend familial;1.9;C07.03.01;Ordre publicDifférend familial;OK;OK;;;;;;
+Circonstances Natures de Faits;$.qualification.whatsHappen;2.3;C02.19.02;Non représentation d’enfant;1.9;C07.03.02;Ordre publicNon représentation d’enfant;OK;OK;;;;;;
+Circonstances Natures de Faits;$.qualification.whatsHappen;2.3;C02.19.03;Différend de voisinage;1.9;C07.03.03;Ordre publicDifférend de voisinage;OK;OK;;;;;;
+Circonstances Natures de Faits;$.qualification.whatsHappen;2.3;C02.19.04;Autres différends;1.9;C07.03.04;Ordre publicAutres différends;OK;OK;;;;;;
+Circonstances Natures de Faits;$.qualification.whatsHappen;2.3;C02.19.05;Litiges;1.9;C07.03.05;Ordre publicLitiges;OK;OK;;;;;;
+Circonstances Natures de Faits;$.qualification.whatsHappen;2.3;C04.01.12;Incendie engin de chantier ou agricole;1.9;C04.01.00;Incendie d'un moyen de transport / véhicule;OK;OK;;;;;;
+Circonstances Natures de Faits;$.qualification.whatsHappen;2.3;C04.01.13;Incendie plusieurs véhicules légers;1.9;C04.01.01;Véhicule léger, fourgon;OK;OK;;;;;;
+Circonstances Natures de Faits;$.qualification.whatsHappen;2.3;C04.01.14;Incendie Tram / tramway;1.9;C04.01.05;Train de voyageurs;OK;OK;;;;;;
+Circonstances Natures de Faits;$.qualification.whatsHappen;2.3;C04.01.15;Incendie bateau de plaisance;1.9;C04.01.07;Bateau de voyageurs;OK;OK;;;;;;
+Circonstances Natures de Faits;$.qualification.whatsHappen;2.3;C04.01.16;Incendie bateau de pêche;1.9;C04.01.08;Bateau de marchandises;OK;OK;;;;;;
+Circonstances Natures de Faits;$.qualification.whatsHappen;2.3;C04.01.17;Incendie bateau de guerre;1.9;C04.01.08;Bateau de marchandises;OK;OK;;;;;;
+Circonstances Natures de Faits;$.qualification.whatsHappen;2.3;C04.01.18;Incendie ULM / planeur / mongolfière;1.9;C04.01.10;Aéronef de voyageurs;OK;OK;;;;;;
+Circonstances Natures de Faits;$.qualification.whatsHappen;2.3;C04.01.19;Incendie aéronef de tourisme;1.9;C04.01.10;Aéronef de voyageurs;OK;OK;;;;;;
+Circonstances Natures de Faits;$.qualification.whatsHappen;2.3;C04.02.05;Incendie d'ERP avec locaux à sommeil;1.9;C04.02.00;Incendie d'un bâtiment;OK;OK;;;;;;
+Circonstances Natures de Faits;$.qualification.whatsHappen;2.3;C04.02.06;Incendie d'ERP sans locaux à sommeil;1.9;C04.02.00;Incendie d'un bâtiment;OK;OK;;;;;;
+Circonstances Natures de Faits;$.qualification.whatsHappen;2.3;C04.05.01;Incendie de haie / herbes sèches;1.9;C04.05.00;Incendie de forêt / végétation;OK;OK;;;;;;
+Circonstances Natures de Faits;$.qualification.whatsHappen;2.3;C04.05.02;Feu de chaumes / récoltes;1.9;C04.05.00;Incendie de forêt / végétation;OK;OK;;;;;;
+Circonstances Natures de Faits;$.qualification.whatsHappen;2.3;C04.05.03;Feu de broussailles;1.9;C04.05.00;Incendie de forêt / végétation;OK;OK;;;;;;
+Circonstances Natures de Faits;$.qualification.whatsHappen;2.3;C04.05.04;Feu de forêt;1.9;C04.05.00;Incendie de forêt / végétation;OK;OK;;;;;;
+Circonstances Natures de Faits;$.qualification.whatsHappen;2.3;C04.10.00;Incendie d'un élément / structure;1.9;C04.02.00;Incendie d'un bâtiment;OK;OK;;;;;;
+Circonstances Natures de Faits;$.qualification.whatsHappen;2.3;C04.10.01;Feu de cheminée;1.9;C04.02.00;Incendie d'un bâtiment;OK;OK;;;;;;
+Circonstances Natures de Faits;$.qualification.whatsHappen;2.3;C04.10.02;Incendie d'origine électrique;1.9;C04.08.00;Autre type d’incendie;OK;OK;;;;;;
+Circonstances Natures de Faits;$.qualification.whatsHappen;2.3;C04.10.03;Autre feu d'un élément / structure;1.9;C04.08.00;Autre type d’incendie;OK;OK;;;;;;
+Circonstances Natures de Faits;$.qualification.whatsHappen;2.3;C04.11.00;Fumée suspecte / levée de doute;1.9;C04.00.00;Incendie;OK;OK;;;;;;
+Circonstances Natures de Faits;$.qualification.whatsHappen;2.3;C06.03.07;Refus d'obtempérer;1.9;C06.03.00;Suspicion d'infractions;OK;OK;;;;;;
+Circonstances Natures de Faits;$.qualification.whatsHappen;2.3;C07.02.01;Affrontement bande;1.9;C07.02.00;Violence urbaine;OK;OK;;;;;;
+Circonstances Natures de Faits;$.qualification.whatsHappen;2.3;C07.02.02;Dégradation mobilier urbain;1.9;C07.13.00;Autres troubles à l’ordre public;OK;OK;;;;;;
+Circonstances Natures de Faits;$.qualification.whatsHappen;2.3;C07.02.03;Incendie;1.9;C04.08.00;Autre type d’incendie;OK;OK;;;;;;
+Circonstances Natures de Faits;$.qualification.whatsHappen;2.3;C07.02.04;Autres violences urbaines;1.9;C07.02.00;Violence urbaine;OK;OK;;;;;;
+Circonstances Natures de Faits;$.qualification.whatsHappen;2.3;C08.01.01;Inondation - montée des eaux inquiétante;1.9;C08.01.00;Inondation;OK;OK;;;;;;
+Circonstances Natures de Faits;$.qualification.whatsHappen;2.3;C08.01.02;Inondation d'un batiment, local;1.9;C08.01.00;Inondation;OK;OK;;;;;;
+Circonstances Natures de Faits;$.qualification.whatsHappen;2.3;C08.05.01;Vent / Tempête avec chute d'arbres;1.9;C08.05.00;Vent / Tempête;OK;OK;;;;;;
+Circonstances Natures de Faits;$.qualification.whatsHappen;2.3;C08.05.02;Vent / Tempête avec dommages sur toitures;1.9;C08.05.00;Vent / Tempête;OK;OK;;;;;;
+Circonstances Natures de Faits;$.qualification.whatsHappen;2.3;C08.06.01;Éboulement / Effondrement de bâtiment;1.9;C08.06.00;Éboulement / effondrement;OK;OK;;;;;;
+Circonstances Natures de Faits;$.qualification.whatsHappen;2.3;C08.06.02;Éboulement / Effondrement de carrière;1.9;C08.06.00;Éboulement / effondrement;OK;OK;;;;;;
+Circonstances Natures de Faits;$.qualification.whatsHappen;2.3;C08.06.03;Autre éboulement, effondrement;1.9;C08.06.00;Éboulement / effondrement;OK;OK;;;;;;
+Circonstances Natures de Faits;$.qualification.whatsHappen;2.3;C08.08.03;Pollution aérienne;1.9;C08.08.00;Aléas naturel / environnemental / météorologique;OK;OK;;;;;;
+Circonstances Natures de Faits;$.qualification.whatsHappen;2.3;C08.08.04;Pollution fut / bidon suspect;1.9;C08.08.00;Aléas naturel / environnemental / météorologique;OK;OK;;;;;;
+Circonstances Natures de Faits;$.qualification.whatsHappen;2.3;C09.03.02;Fuite de gaz enflammée (réseau);1.9;C09.03.01;Fuite de gaz importante;OK;OK;;;;;;
+Circonstances Natures de Faits;$.qualification.whatsHappen;2.3;C09.03.03;Fuite de gaz non enflammée (réseau);1.9;C09.03.01;Fuite de gaz importante;OK;OK;;;;;;
+Circonstances Natures de Faits;$.qualification.whatsHappen;2.3;C09.03.04;Fuite de gaz sur bouteille;1.9;C09.03.00;Fuite de gaz;OK;OK;;;;;;
+Circonstances Natures de Faits;$.qualification.whatsHappen;2.3;C09.04.03;Vapeur sous pression / chauffage urbain;1.9;C09.04.02;Fuite de fluides gazeux;OK;OK;;;;;;
+Circonstances Natures de Faits;$.qualification.whatsHappen;2.3;C09.05.01;Immeuble en péril;1.9;C09.00.00;Aléas technologique ou technique;OK;OK;;;;;;
+Circonstances Natures de Faits;$.qualification.whatsHappen;2.3;C09.05.02;Menace ou chute de matériaux;1.9;C09.00.00;Aléas technologique ou technique;OK;OK;;;;;;
+Circonstances Natures de Faits;$.qualification.whatsHappen;2.3;C09.06.01;Panne d’ascenseur avec présence de personne vulnérable;1.9;C09.06.00;Panne d’ascenseur;OK;OK;;;;;;
+Circonstances Natures de Faits;$.qualification.whatsHappen;2.3;C09.06.02;Panne d’ascenseur vide d'occupant;1.9;C09.06.00;Panne d’ascenseur;OK;OK;;;;;;
+Circonstances Natures de Faits;$.qualification.whatsHappen;2.3;C11.01.01;Alarme incendie;1.9;C11.01.00;Alarme;OK;OK;;;;;;
+Circonstances Natures de Faits;$.qualification.whatsHappen;2.3;C11.01.02;Alarme vol / intrusion;1.9;C11.01.00;Alarme;OK;OK;;;;;;
+Circonstances Natures de Faits;$.qualification.whatsHappen;2.3;C11.01.03;Téléalarme secours à personne (applications);1.9;C11.01.00;Alarme;OK;OK;;;;;;
+Circonstances Natures de Faits;$.qualification.whatsHappen;2.3;C11.01.04;Alarme dispositif travailleur isolé;1.9;C11.01.00;Alarme;OK;OK;;;;;;
+Circonstances Natures de Faits;$.qualification.whatsHappen;2.3;C11.01.05;Simple alarme sans précision;1.9;C11.01.00;Alarme;OK;OK;;;;;;
+Circonstances Natures de Faits;$.qualification.whatsHappen;2.3;C11.05.04;Problème technique sur un véhicule;1.9;C11.05.00;Autre nature de fait;OK;OK;;;;;;
+Circonstances Natures de Faits;$.qualification.whatsHappen;2.3;C11.05.05;Obstruction de chaussée;1.9;C11.05.00;Autre nature de fait;OK;OK;;;;;;
+Circonstances Natures de Faits;$.qualification.whatsHappen;2.3;C11.05.06;Obstruction de voie ferrée;1.9;C11.05.00;Autre nature de fait;OK;OK;;;;;;
+Circonstances Natures de Faits;$.qualification.whatsHappen;2.3;C11.05.07;Obstruction de voie naviguable;1.9;C11.05.00;Autre nature de fait;OK;OK;;;;;;
+Circonstances Natures de Faits;$.qualification.whatsHappen;2.3;C11.07.00;Requisition judiciaire;1.9;C11.00.00;Autre nature de fait;OK;OK;;;;;;
+Circonstances Natures de Faits;$.qualification.whatsHappen;2.3;C11.08.00;Odeur suspecte;1.9;C11.00.00;Autre nature de fait;OK;OK;;;;;;
+Motif de recours médico secouriste;$.qualification.healthMotive;1.9;M20.00;Urgences vitales;2.3;M08.00.00;Personne inconsciente ;OK;OK;le moins mauvais;;;;;
+Motif de recours médico secouriste;$.qualification.healthMotive;1.9;M22.00;Personne inconsciente;2.3;M08.00.00;Personne inconsciente ;OK;OK;;;;;;
+Motif de recours médico secouriste;$.qualification.healthMotive;1.9;M22.01;Pas de mouvement ventilatoire;2.3;M08.01.00;Personne en arrêt ventilatoire;OK;OK;;;;;;
+Motif de recours médico secouriste;$.qualification.healthMotive;1.9;M22.11;Arrêt cardio-respiratoire;2.3;M08.02.00;Personne en arrêt cardio-respiratoire;OK;OK;;;;;;
+Motif de recours médico secouriste;$.qualification.healthMotive;1.9;M22.21;Inconscient qui respire;2.3;M08.03.00;Personne inconsciente qui respire;OK;OK;;;;;;
+Motif de recours médico secouriste;$.qualification.healthMotive;1.9;M24.00;Hémorragies / Saignements;2.3;M09.00.00;Hémorragies / Saignements ;OK;OK;;;;;;
+Motif de recours médico secouriste;$.qualification.healthMotive;1.9;M24.01;Hémorragie ne pouvant être stoppée;2.3;M09.01.00;Hémorragie ne pouvant être stoppée;OK;OK;;;;;;
+Motif de recours médico secouriste;$.qualification.healthMotive;1.9;M24.02;Hémorragie ne pouvant être stoppée - Epistaxis non stoppée par la compression;2.3;M09.01.01;Epitaxis non stoppée par compression;OK;OK;;;;;;
+Motif de recours médico secouriste;$.qualification.healthMotive;1.9;M24.11;Hémorragie;2.3;M09.00.00;Hémorragies / Saignements ;OK;OK;;;;;;
+Motif de recours médico secouriste;$.qualification.healthMotive;1.9;M24.21;Hémorragie extériorisée;2.3;M09.02.00;Hémorragie extériorisée;OK;OK;;;;;;
+Motif de recours médico secouriste;$.qualification.healthMotive;1.9;M24.25;Hémorragie extériorisée - Hémorragie digestive (haute ou basse);2.3;M09.02.01;Hémorragie digestive (haute ou basse) extériorirée;OK;OK;;;;;;
+Motif de recours médico secouriste;$.qualification.healthMotive;1.9;M24.26;Hémorragie extériorisée - Malaise;2.3;M09.02.02;Hémorragie extériorisée avec malaise ;OK;OK;;;;;;
+Motif de recours médico secouriste;$.qualification.healthMotive;1.9;M24.27;Hémorragie extériorisée - Crache du sang en toussant;2.3;M09.02.03;Crache du sang hémoptysie;OK;OK;;;;;;
+Motif de recours médico secouriste;$.qualification.healthMotive;1.9;M24.28;Hémorragie extériorisée - Saignement peut être stoppé par compression;2.3;M09.02.04;Saignement stoppé par compression;OK;OK;;;;;;
+Motif de recours médico secouriste;$.qualification.healthMotive;1.9;M24.29;Hémorragie extériorisée - Epistaxis stoppée par compression;2.3;M09.02.05;Epistaxis stoppée par compression;OK;OK;;;;;;
+Motif de recours médico secouriste;$.qualification.healthMotive;1.9;M24.91;Saignements bénins;2.3;M09.03.00;Saignements bénins;OK;OK;;;;;;
+Motif de recours médico secouriste;$.qualification.healthMotive;1.9;M24.92;Saignements bénins - Saignement sans signe de gravité identifié;2.3;M09.03.01;Saignement bénin sans signe de gravité identifié;OK;OK;;;;;;
+Motif de recours médico secouriste;$.qualification.healthMotive;1.9;M30.00;Circulatoire;2.3;M10.00.00;Problème circulatoire;OK;OK;;;;;;
+Motif de recours médico secouriste;$.qualification.healthMotive;1.9;M30.61;Palpitations;2.3;M10.01.00;Palpitations;OK;OK;;;;;;
+Motif de recours médico secouriste;$.qualification.healthMotive;1.9;M30.91;Autres troubles;2.3;M10.02.00;Autres troubles circulatoires;OK;OK;;;;;;
+Motif de recours médico secouriste;$.qualification.healthMotive;1.9;M30.92;Autres troubles - Victime déjà choquée par un DAI;2.3;M10.02.01;Patient/victime choquée par défibrillateur implanté;OK;OK;;;;;;
+Motif de recours médico secouriste;$.qualification.healthMotive;1.9;M30.93;Autres troubles - Fréquence cardiaque < 50 ou > 150;2.3;M10.02.02;Bradycardie < 50 ou tachycardie > 150;OK;OK;;;;;;
+Motif de recours médico secouriste;$.qualification.healthMotive;1.9;M30.95;Autres troubles - Tension artérielle < 90 mm Hg;2.3;M10.02.03;Pression Artérielle < 90 mmHg;OK;OK;;;;;;
+Motif de recours médico secouriste;$.qualification.healthMotive;1.9;M30.96;Autres troubles - Tension artérielle > 160 mm Hg;2.3;M10.02.04;Pression Artérielle > 160 mmHg;OK;OK;;;;;;
+Motif de recours médico secouriste;$.qualification.healthMotive;1.9;M30.97;Autres troubles - Autre trouble sans signe de gravité identifié;2.3;M10.02.05;Autre trouble sans signe de gravité;OK;OK;;;;;;
+Motif de recours médico secouriste;$.qualification.healthMotive;1.9;M31.00;Respiration;2.3;M11.00.00;Problème respiratoire;OK;OK;;;;;;
+Motif de recours médico secouriste;$.qualification.healthMotive;1.9;M31.01;Détresse respiratoire;2.3;M11.01.00;Détresse respiratoire;OK;OK;;;;;;
+Motif de recours médico secouriste;$.qualification.healthMotive;1.9;M31.02;Détresse respiratoire - Etat asphyxique (moins de 4 syllabes ou mots courts, cyanose), ou obstruction complète;2.3;M11.01.01;Détresse respiratoire avec asphyxie;OK;OK;;;;;;
+Motif de recours médico secouriste;$.qualification.healthMotive;1.9;M31.03;Détresse respiratoire - Epuisement respiratoire chez un nourrisson ou signes de lutte;2.3;M11.01.02;Epuisement respiratoire chez un nourrisson ;OK;OK;;;;;;
+Motif de recours médico secouriste;$.qualification.healthMotive;1.9;M31.11;Difficultés respiratoires;2.3;M11.02.00;Difficultés respiratoires;OK;OK;;;;;;
+Motif de recours médico secouriste;$.qualification.healthMotive;1.9;M31.12;Difficultés respiratoires - Respiration bruyante;2.3;M11.02.01;Respiration bruyante;OK;OK;;;;;;
+Motif de recours médico secouriste;$.qualification.healthMotive;1.9;M31.13;Difficultés respiratoires - Sueurs et/ou troubles de conscience;2.3;M11.02.02;Difficultés respiratoires avec sueurs ou altération de conscience;OK;OK;;;;;;
+Motif de recours médico secouriste;$.qualification.healthMotive;1.9;M31.19;Difficultés respiratoires - Difficultés respiratoires sans signe de gravité identifié;2.3;M11.02.03;Difficultés respiratoires sans signe de gravité;OK;OK;;;;;;
+Motif de recours médico secouriste;$.qualification.healthMotive;1.9;M31.91;Autres problème respiratoire;2.3;M11.03.00;Autre problème respiratoire ;OK;OK;;;;;;
+Motif de recours médico secouriste;$.qualification.healthMotive;1.9;M31.92;Autres problème respiratoire - Problème isolé d appareillage respiratoire ou canule;2.3;M11.03.01;Problème isolé d'appareillage respiratoire ou canule ;OK;OK;;;;;;
+Motif de recours médico secouriste;$.qualification.healthMotive;1.9;M31.93;Autres problème respiratoire - Corps étranger expulsé;2.3;M11.03.02;Corps étranger expulsé des poumons;OK;OK;;;;;;
+Motif de recours médico secouriste;$.qualification.healthMotive;1.9;M31.94;Autres problème respiratoire - Obstruction partielle;2.3;M11.03.03;Problème respiratoire avec obstruction partielle;OK;OK;;;;;;
+Motif de recours médico secouriste;$.qualification.healthMotive;1.9;M31.99;Autres problème respiratoire - Autres problème respiratoire sans signe de gravité identifié;2.3;M11.03.04;Autre problème respiratoire sans signe de gravité;OK;OK;;;;;;
+Motif de recours médico secouriste;$.qualification.healthMotive;1.9;M32.00;Neurologie;2.3;M12.00.00;Problème neurologique;OK;OK;;;;;;
+Motif de recours médico secouriste;$.qualification.healthMotive;1.9;M32.01;Suspicion AVC / AIT;2.3;M12.01.00;Suspicion AVC / AIT;OK;OK;;;;;;
+Motif de recours médico secouriste;$.qualification.healthMotive;1.9;M32.02;Suspicion AVC / AIT - Avec troubles de la conscience;2.3;M12.01.01;Suspicion AVC / AIT avec trouble de conscience ;OK;OK;;;;;;
+Motif de recours médico secouriste;$.qualification.healthMotive;1.9;M32.03;Suspicion AVC / AIT - Avec céphalées ou vomissements;2.3;M12.01.00;Suspicion AVC / AIT;OK;OK;;;;;;
+Motif de recours médico secouriste;$.qualification.healthMotive;1.9;M32.04;Suspicion AVC / AIT - Sans céphalée ou vomissement ni trouble de la conscience;2.3;M12.01.02;Suspicion AVC / AIT sans céphalée ou vomissement ni trouble de la conscience;OK;OK;;;;;;
+Motif de recours médico secouriste;$.qualification.healthMotive;1.9;M32.05;Suspicion AVC / AIT - Avec disparition des signes associés à l‘AVC au moment de l‘appel;2.3;M12.01.03;Suspicion AVC / AIT avec disparition des signes d'AVC à l'appel;OK;OK;;;;;;
+Motif de recours médico secouriste;$.qualification.healthMotive;1.9;M32.11;Convulsions persistantes;2.3;M12.02.00;Convulsions persistantes;OK;OK;;;;;;
+Motif de recours médico secouriste;$.qualification.healthMotive;1.9;M32.21;Convulsions;2.3;M12.03.00;Convulsions ;OK;OK;;;;;;
+Motif de recours médico secouriste;$.qualification.healthMotive;1.9;M32.22;Convulsions - Chez la femme enceinte;2.3;M12.03.01;Convulsions  - Chez la femme enceinte ;OK;OK;;;;;;
+Motif de recours médico secouriste;$.qualification.healthMotive;1.9;M32.24;Convulsions - Réveil après convulsions;2.3;M12.03.03;En cours de réveil après convulsions;OK;OK;;;;;;
+Motif de recours médico secouriste;$.qualification.healthMotive;1.9;M32.25;Convulsions - Hyperthermiques de l‘enfant;2.3;M12.03.02;Convulsions avec fièvre chez l'enfant;OK;OK;;;;;;
+Motif de recours médico secouriste;$.qualification.healthMotive;1.9;M32.31;Trouble de la conscience;2.3;M12.04.00;Trouble de la conscience ;OK;OK;;;;;;
+Motif de recours médico secouriste;$.qualification.healthMotive;1.9;M32.32;Trouble de la conscience - Chez le diabétique;2.3;M12.04.01;Trouble de la conscience chez un diabétique;OK;OK;;;;;;
+Motif de recours médico secouriste;$.qualification.healthMotive;1.9;M32.34;Trouble de la conscience - Avec perte de connaissance initiale;2.3;M12.04.02;Trouble de la conscience avec perte de connaissance initiale;OK;OK;;;;;;
+Motif de recours médico secouriste;$.qualification.healthMotive;1.9;M32.35;Trouble de la conscience - Somnolent et capable de parler ou de répondre à des ordres simples;2.3;M12.04.03;Somnolent et capable de parler ou de répondre à des ordres simples;OK;OK;;;;;;
+Motif de recours médico secouriste;$.qualification.healthMotive;1.9;M32.36;Trouble de la conscience - Confusion, désorientation;2.3;M12.04.04;Confusion, désorientation;OK;OK;;;;;;
+Motif de recours médico secouriste;$.qualification.healthMotive;1.9;M32.39;Trouble de la conscience - Trouble de la conscience sans signe de gravité identifié;2.3;M12.04.05;Autre trouble de la conscience sans signe de gravité;OK;OK;;;;;;
+Motif de recours médico secouriste;$.qualification.healthMotive;1.9;M32.51;Malaise;2.3;M12.05.00;Malaise;OK;OK;;;;;;
+Motif de recours médico secouriste;$.qualification.healthMotive;1.9;M32.52;Malaise - Malaise d effort;2.3;M12.05.02;Malaise au cours d'un effort;OK;OK;;;;;;
+Motif de recours médico secouriste;$.qualification.healthMotive;1.9;M32.54;Malaise - Avec perte de connaissance initiale;2.3;M12.05.03;Malaise avec perte de connaissance initiale;OK;OK;;;;;;
+Motif de recours médico secouriste;$.qualification.healthMotive;1.9;M32.55;Malaise - Avec trouble de la conscience;2.3;M12.05.04;Malaise avec trouble de la conscience;OK;OK;;;;;;
+Motif de recours médico secouriste;$.qualification.healthMotive;1.9;M32.57;Malaise - Malaise sans signe de gravité identifié;2.3;M12.05.01;Malaise sans signe de gravité;OK;OK;;;;;;
+Motif de recours médico secouriste;$.qualification.healthMotive;1.9;M32.91;Autre motif neurologique;2.3;M12.06.00;Autre motif neurologique ;OK;OK;;;;;;
+Motif de recours médico secouriste;$.qualification.healthMotive;1.9;M32.92;Autre motif neurologique - Céphalées;2.3;M12.06.01;Céphalées isolées;OK;OK;;;;;;
+Motif de recours médico secouriste;$.qualification.healthMotive;1.9;M32.95;Autre motif neurologique - Céphalées avec vomissement;2.3;M12.06.02;Céphalées avec vomissement;OK;OK;;;;;;
+Motif de recours médico secouriste;$.qualification.healthMotive;1.9;M32.99;Autre motif neurologique - Autre motif neurologique sans signe de gravité identifié;2.3;M12.06.03;Autre motif neurologique sans signe de gravité;OK;OK;;;;;;
+Motif de recours médico secouriste;$.qualification.healthMotive;1.9;M41.00;Traumatisme;2.3;M13.00.00;Traumatisme;OK;OK;;;;;;
+Motif de recours médico secouriste;$.qualification.healthMotive;1.9;M41.01;Personne restant à terre suite à une chute;2.3;M13.01.00;Personne restant à terre suite à une chute;OK;OK;;;;;;
+Motif de recours médico secouriste;$.qualification.healthMotive;1.9;M41.11;Suspicion de victime polytraumatisé;2.3;M13.02.00;Polytraumatisme / traumatisme sévère;OK;OK;;;;;;
+Motif de recours médico secouriste;$.qualification.healthMotive;1.9;M41.21;Traumatisme tête - cou;2.3;M13.03.00;Traumatisme tête / cou;OK;OK;;;;;;
+Motif de recours médico secouriste;$.qualification.healthMotive;1.9;M41.22;Traumatisme tête - cou - Avec perte de connaissance ou troubles de la la conscience;2.3;M13.03.01;Traumatisme tête / cou avec perte de connaissance initiale ou troubles de la conscience;OK;OK;;;;;;
+Motif de recours médico secouriste;$.qualification.healthMotive;1.9;M41.29;Traumatisme tête - cou - Trauma tête / cou sans signe de gravité;2.3;M13.03.02;Traumatisme tête / cou sans signe de gravité;OK;OK;;;;;;
+Motif de recours médico secouriste;$.qualification.healthMotive;1.9;M41.31;Traumatisme thorax;2.3;M13.04.00;Traumatisme thorax;OK;OK;;;;;;
+Motif de recours médico secouriste;$.qualification.healthMotive;1.9;M41.32;Traumatisme thorax - Avec gêne respiratoire;2.3;M13.04.01;Traumatisme thorax avec gêne respiratoire;OK;OK;;;;;;
+Motif de recours médico secouriste;$.qualification.healthMotive;1.9;M41.39;Traumatisme thorax - Traumatisme au thorax sans signe de gravité;2.3;M13.04.02;Traumatisme thorax sans signe de gravité;OK;OK;;;;;;
+Motif de recours médico secouriste;$.qualification.healthMotive;1.9;M41.41;Traumatisme abdomen - bassin;2.3;M13.05.00;Traumatisme abdomen / bassin;OK;OK;;;;;;
+Motif de recours médico secouriste;$.qualification.healthMotive;1.9;M41.42;Traumatisme abdomen - bassin - Choc violent;2.3;M13.05.01;Traumatisme abdomen / bassin violent;OK;OK;;;;;;
+Motif de recours médico secouriste;$.qualification.healthMotive;1.9;M41.49;Traumatisme abdomen - bassin - Traumatisme abdomen - bassin sans signe de gravité;2.3;M13.05.02;Traumatisme abdomen / bassin sans signe de gravité;OK;OK;;;;;;
+Motif de recours médico secouriste;$.qualification.healthMotive;1.9;M41.51;Traumatisme membres;2.3;M13.06.00;Traumatisme membres;OK;OK;;;;;;
+Motif de recours médico secouriste;$.qualification.healthMotive;1.9;M41.52;Traumatisme membres - Amputation;2.3;M13.06.01;Traumatisme membre avec amputation;OK;OK;;;;;;
+Motif de recours médico secouriste;$.qualification.healthMotive;1.9;M41.53;Traumatisme membres - Fracture ouverte;2.3;M13.06.02;Fracture ouverte de membre;OK;OK;;;;;;
+Motif de recours médico secouriste;$.qualification.healthMotive;1.9;M41.54;Traumatisme membres - Fracture fermée;2.3;M13.06.03;Fracture fermée de membre;OK;OK;;;;;;
+Motif de recours médico secouriste;$.qualification.healthMotive;1.9;M41.55;Traumatisme membres - déformation;2.3;M13.06.04;Traumatisme avec déformation de membre;OK;OK;;;;;;
+Motif de recours médico secouriste;$.qualification.healthMotive;1.9;M41.59;Traumatisme membres - Traumatisme de membres sans signe de gravité;2.3;M13.06.05;Traumatisme de membres sans signe de gravité;OK;OK;;;;;;
+Motif de recours médico secouriste;$.qualification.healthMotive;1.9;M41.61;Traumatisme doigts - orteils;2.3;M13.07.00;Traumatisme doigts - orteils;OK;OK;;;;;;
+Motif de recours médico secouriste;$.qualification.healthMotive;1.9;M41.62;Traumatisme doigts - orteils - Amputation;2.3;M13.07.01;Traumatisme doigts / orteils avec amputation;OK;OK;;;;;;
+Motif de recours médico secouriste;$.qualification.healthMotive;1.9;M41.64;Traumatisme doigts - orteils - Fracture ouverte;2.3;M13.07.02;Fracture ouverte de doigts / orteils ;OK;OK;;;;;;
+Motif de recours médico secouriste;$.qualification.healthMotive;1.9;M41.65;Traumatisme doigts - orteils - Fracture fermée;2.3;M13.07.03;Fracture fermée doigts / orteils ;OK;OK;;;;;;
+Motif de recours médico secouriste;$.qualification.healthMotive;1.9;M41.66;Traumatisme doigts - orteils - Déformation;2.3;M13.07.04;Traumatisme doigts / orteils  avec déformation;OK;OK;;;;;;
+Motif de recours médico secouriste;$.qualification.healthMotive;1.9;M41.69;Traumatisme doigts - orteils - Traumatisme de doigt - orteil sans signe de gravité;2.3;M13.07.05;Traumatisme doigts / orteils  sans signe de gravité;OK;OK;;;;;;
+Motif de recours médico secouriste;$.qualification.healthMotive;1.9;M45.00;Plaies;2.3;M14.00.00;Plaies;OK;OK;;;;;;
+Motif de recours médico secouriste;$.qualification.healthMotive;1.9;M45.01;Pénétrante;2.3;M14.01.00;Plaie pénétrante;OK;OK;;;;;;
+Motif de recours médico secouriste;$.qualification.healthMotive;1.9;M45.02;Etendue;2.3;M14.01.01;Plaie pénétrante étendue;OK;OK;;;;;;
+Motif de recours médico secouriste;$.qualification.healthMotive;1.9;M45.03;Multiples;2.3;M14.01.02;Plaies pénétrantes multiples;OK;OK;;;;;;
+Motif de recours médico secouriste;$.qualification.healthMotive;1.9;M45.05;Plaie grave du crâne (scalp);2.3;M14.01.03;Plaie grave du crâne (scalp);OK;OK;;;;;;
+Motif de recours médico secouriste;$.qualification.healthMotive;1.9;M45.06;Plaie grave du visage;2.3;M14.01.04;Plaie grave du visage;OK;OK;;;;;;
+Motif de recours médico secouriste;$.qualification.healthMotive;1.9;M45.07;Plaie grave du cou;2.3;M14.01.05;Plaie grave du cou;OK;OK;;;;;;
+Motif de recours médico secouriste;$.qualification.healthMotive;1.9;M45.08;Plaie grave du thorax - abdomen;2.3;M14.01.06;Plaie grave du thorax - abdomen;OK;OK;;;;;;
+Motif de recours médico secouriste;$.qualification.healthMotive;1.9;M45.09;Pâleur, soif, prostation;2.3;M14.01.07;Plaie grave avec pâleur/soif/prostration;OK;OK;;;;;;
+Motif de recours médico secouriste;$.qualification.healthMotive;1.9;M45.31;Morsure;2.3;M14.02.00;Morsure;OK;OK;;;;;;
+Motif de recours médico secouriste;$.qualification.healthMotive;1.9;M45.32;Morsure - Morsure grave;2.3;M14.02.01;Morsure grave;OK;OK;;;;;;
+Motif de recours médico secouriste;$.qualification.healthMotive;1.9;M45.33;Morsure - Morsure sans signe de gravité;2.3;M14.02.02;Morsure sans signe de gravité;OK;OK;;;;;;
+Motif de recours médico secouriste;$.qualification.healthMotive;1.9;M46.00;Brûlures;2.3;M15.00.00;Brûlures;OK;OK;;;;;;
+Motif de recours médico secouriste;$.qualification.healthMotive;1.9;M46.01;Brûlure thermique;2.3;M15.01.00;Brûlure thermique;OK;OK;;;;;;
+Motif de recours médico secouriste;$.qualification.healthMotive;1.9;M46.02;Brûlure thermique - Brûlure étendue / circulaire ou tronc / face / cou;2.3;M15.01.01;Brûlure thermique grave (étendue / circulaire / tronc / face / cou);OK;OK;;;;;;
+Motif de recours médico secouriste;$.qualification.healthMotive;1.9;M46.03;Brûlure thermique - Brûlure à l‘oeil;2.3;M15.01.02;Brûlure thermique à l'œil;OK;OK;;;;;;
+Motif de recours médico secouriste;$.qualification.healthMotive;1.9;M46.09;Brûlure thermique - Brûlure thermique sans signe de gravité identifié;2.3;M15.01.03;Brûlure thermique sans signe de gravité;OK;OK;;;;;;
+Motif de recours médico secouriste;$.qualification.healthMotive;1.9;M46.11;Brûlure chimique;2.3;M15.02.00;Brûlure chimique;OK;OK;;;;;;
+Motif de recours médico secouriste;$.qualification.healthMotive;1.9;M46.12;Brûlure chimique - Brûlure étendue / circulaire ou tronc / face / cou;2.3;M15.02.01;Brûlure chimique grave (étendue / circulaire / tronc / face / cou);OK;OK;;;;;;
+Motif de recours médico secouriste;$.qualification.healthMotive;1.9;M46.13;Brûlure chimique - Brûlure à l‘oeil;2.3;M15.02.02;Brûlure à l'œil;OK;OK;;;;;;
+Motif de recours médico secouriste;$.qualification.healthMotive;1.9;M46.19;Brûlure chimique - Brûlure chimique sans signe de gravité identifié;2.3;M15.02.03;Brûlure chimique sans signe de gravité;OK;OK;;;;;;
+Motif de recours médico secouriste;$.qualification.healthMotive;1.9;M46.21;Gelure;2.3;M15.03.00;Gelure;OK;OK;;;;;;
+Motif de recours médico secouriste;$.qualification.healthMotive;1.9;M46.22;Gelure - Gelure grave;2.3;M15.03.01;Gelure grave;OK;OK;;;;;;
+Motif de recours médico secouriste;$.qualification.healthMotive;1.9;M46.29;Gelure - Gelure sans signe de gravité identifié;2.3;M15.03.02;Gelure sans signe de gravité;OK;OK;;;;;;
+Motif de recours médico secouriste;$.qualification.healthMotive;1.9;M50.00;Intoxication;2.3;M16.00.00;Intoxication;OK;OK;;;;;;
+Motif de recours médico secouriste;$.qualification.healthMotive;1.9;M50.11;Intoxication au CO / fumées;2.3;M16.01.00;Intoxication au CO / fumées;OK;OK;;;;;;
+Motif de recours médico secouriste;$.qualification.healthMotive;1.9;M50.12;Intoxication au CO / fumées - Avec convulsions / troubles de la conscience;2.3;M16.01.01;Intoxication au CO / fumées avec convulsions / troubles de la conscience;OK;OK;;;;;;
+Motif de recours médico secouriste;$.qualification.healthMotive;1.9;M50.15;Intoxication au CO / fumées - Vomissements, céphalées;2.3;M16.01.02;Intoxication au CO / fumées avec vomissements, céphalées;OK;OK;;;;;;
+Motif de recours médico secouriste;$.qualification.healthMotive;1.9;M50.16;Intoxication au CO / fumées - Sans signe de gravité identifié;2.3;M16.01.03;Intoxication au CO / fumées sans signe de gravité;OK;OK;;;;;;
+Motif de recours médico secouriste;$.qualification.healthMotive;1.9;M50.21;Intoxication éthylique ou prise de stupéfiants;2.3;M16.02.00;Intoxication éthylique / prise de stupéfiants ;OK;OK;;;;;;
+Motif de recours médico secouriste;$.qualification.healthMotive;1.9;M50.22;Intoxication éthylique ou prise de stupéfiants - Convulsions et/ou coma;2.3;M16.02.01;Intoxication éthylique / prise de stupéfiants avec convulsions ou coma;OK;OK;;;;;;
+Motif de recours médico secouriste;$.qualification.healthMotive;1.9;M50.25;Intoxication éthylique ou prise de stupéfiants - Somnolence;2.3;M16.02.02;Intoxication éthylique / prise de stupéfiants avec somnolence;OK;OK;;;;;;
+Motif de recours médico secouriste;$.qualification.healthMotive;1.9;M50.29;Intoxication éthylique ou prise de stupéfiants - Sans signe de gravité identifié;2.3;M16.02.03;Intoxication éthylique / prise de stupéfiants sans signe de gravité;OK;OK;;;;;;
+Motif de recours médico secouriste;$.qualification.healthMotive;1.9;M50.31;Médicamenteuse;2.3;M16.03.00;Intoxication médicamenteuse ;OK;OK;;;;;;
+Motif de recours médico secouriste;$.qualification.healthMotive;1.9;M50.32;Médicamenteuse - Convulsions et/ou coma;2.3;M16.03.01;Intoxication médicamenteuse avec convulsions ou coma;OK;OK;;;;;;
+Motif de recours médico secouriste;$.qualification.healthMotive;1.9;M50.33;Médicamenteuse - Détresse respiratoire;2.3;M16.03.02;Intoxication médicamenteuse avec détresse respiratoire ;OK;OK;;;;;;
+Motif de recours médico secouriste;$.qualification.healthMotive;1.9;M50.35;Médicamenteuse - Somnolence;2.3;M16.03.03;Intoxication médicamenteuse avec somnolence;OK;OK;;;;;;
+Motif de recours médico secouriste;$.qualification.healthMotive;1.9;M50.39;Médicamenteuse - Sans signe de gravité identifié;2.3;M16.03.04;Intoxication médicamenteuse sans signe de gravité;OK;OK;;;;;;
+Motif de recours médico secouriste;$.qualification.healthMotive;1.9;M50.51;Chimiques / venimeuses;2.3;M16.04.00;Intoxication chimique / venimeuse;OK;OK;;;;;;
+Motif de recours médico secouriste;$.qualification.healthMotive;1.9;M50.52;Chimiques / venimeuses - Avec convulsions / troubles de la conscience;2.3;M16.04.01;Intoxication chimique / venimeuse avec convulsions / troubles de la conscience;OK;OK;;;;;;
+Motif de recours médico secouriste;$.qualification.healthMotive;1.9;M50.53;Chimiques / venimeuses - Détresse respiratoire et/ou toux;2.3;M16.04.02;Intoxication chimique / venimeuse avec détresse respiratoire ou toux;OK;OK;;;;;;
+Motif de recours médico secouriste;$.qualification.healthMotive;1.9;M50.54;Chimiques / venimeuses - Sans signe de gravité identifié;2.3;M16.04.03;Intoxication chimique / venimeuse sans signe de gravité;OK;OK;;;;;;
+Motif de recours médico secouriste;$.qualification.healthMotive;1.9;M50.59;Douleurs ostéoarticulaires - Douleur ostéoarticulaire sans signe de gravité identifié;2.3;M17.04.02;Douleur ostéoarticulaire sans signe de gravité;OK;OK;;;;;;
+Motif de recours médico secouriste;$.qualification.healthMotive;1.9;M60.00;Douleurs;2.3;M17.00.00;Douleurs;OK;OK;;;;;;
+Motif de recours médico secouriste;$.qualification.healthMotive;1.9;M60.01;Céphalées;2.3;M17.01.00;Céphalées;OK;OK;;;;;;
+Motif de recours médico secouriste;$.qualification.healthMotive;1.9;M60.03;Céphalées - Avec troubles de conscience;2.3;M17.01.01;Céphalées avec troubles de conscience;OK;OK;;;;;;
+Motif de recours médico secouriste;$.qualification.healthMotive;1.9;M60.05;Céphalées - Céphalées chez la femme enceinte;2.3;M17.01.02;Céphalées chez la femme enceinte;OK;OK;;;;;;
+Motif de recours médico secouriste;$.qualification.healthMotive;1.9;M60.08;Céphalées - Sans signe de gravité identifiée;2.3;M17.01.03;Céphalées sans signe de gravité;OK;OK;;;;;;
+Motif de recours médico secouriste;$.qualification.healthMotive;1.9;M60.21;Douleurs abdominales;2.3;M17.02.00;Douleurs abdominales ;OK;OK;;;;;;
+Motif de recours médico secouriste;$.qualification.healthMotive;1.9;M60.26;Douleurs abdominales - Sans signe de gravité identifiée;2.3;M17.02.01;Douleurs abdominales sans signe de gravité;OK;OK;;;;;;
+Motif de recours médico secouriste;$.qualification.healthMotive;1.9;M60.31;Douleur thoracique;2.3;M17.03.00;Douleur thoracique ;OK;OK;;;;;;
+Motif de recours médico secouriste;$.qualification.healthMotive;1.9;M60.32;Douleur thoracique - Avec antécédent infarctus et/ou même douleur;2.3;M17.03.00;Douleur thoracique ;OK;OK;;;;;;
+Motif de recours médico secouriste;$.qualification.healthMotive;1.9;M60.33;Douleur thoracique - Douleur médiane en étau;2.3;M17.03.00;Douleur thoracique ;OK;OK;;;;;;
+Motif de recours médico secouriste;$.qualification.healthMotive;1.9;M60.34;Douleur thoracique - Pendant effort ou dans les heures qui suivent;2.3;M17.03.00;Douleur thoracique ;OK;OK;;;;;;
+Motif de recours médico secouriste;$.qualification.healthMotive;1.9;M60.35;Douleur thoracique - Facteurs de risque cardio-vasculaires;2.3;M17.03.00;Douleur thoracique ;OK;OK;;;;;;
+Motif de recours médico secouriste;$.qualification.healthMotive;1.9;M60.36;Douleur thoracique - Pâleur intense;2.3;M17.03.00;Douleur thoracique ;OK;OK;;;;;;
+Motif de recours médico secouriste;$.qualification.healthMotive;1.9;M60.37;Douleur thoracique - Sueurs;2.3;M17.03.00;Douleur thoracique ;OK;OK;;;;;;
+Motif de recours médico secouriste;$.qualification.healthMotive;1.9;M60.38;Douleur thoracique - Nausées;2.3;M17.03.00;Douleur thoracique ;OK;OK;;;;;;
+Motif de recours médico secouriste;$.qualification.healthMotive;1.9;M60.39;Douleur thoracique - Avec palpitations;2.3;M17.03.00;Douleur thoracique ;OK;OK;;;;;;
+Motif de recours médico secouriste;$.qualification.healthMotive;1.9;M60.40;Douleur thoracique - Prise de toxiques récente;2.3;M17.03.00;Douleur thoracique ;OK;OK;;;;;;
+Motif de recours médico secouriste;$.qualification.healthMotive;1.9;M60.41;Douleur thoracique - Douleur thoracique déclenchée par la toux ou la respiration;2.3;M17.03.00;Douleur thoracique ;OK;OK;;;;;;
+Motif de recours médico secouriste;$.qualification.healthMotive;1.9;M60.49;Douleur thoracique - Douleur thoracique sans signe de gravité identifié;2.3;M17.03.00;Douleur thoracique ;OK;OK;;;;;;
+Motif de recours médico secouriste;$.qualification.healthMotive;1.9;M60.51;Douleurs ostéoarticulaires;2.3;M17.04.00;Douleurs ostéoarticulaires ;OK;OK;;;;;;
+Motif de recours médico secouriste;$.qualification.healthMotive;1.9;M60.53;Douleurs ostéoarticulaires - Douleur de membre;2.3;M17.04.01;Douleurs ostéoarticulaires ou de membre;OK;OK;;;;;;
+Motif de recours médico secouriste;$.qualification.healthMotive;1.9;M60.91;Autres douleurs;2.3;M17.05.00;Autres douleurs ;OK;OK;;;;;;
+Motif de recours médico secouriste;$.qualification.healthMotive;1.9;M60.92;Autres douleurs - Douleurs dentaires;2.3;M17.05.01;Douleurs dentaires;OK;OK;;;;;;
+Motif de recours médico secouriste;$.qualification.healthMotive;1.9;M60.93;Autres douleurs - Douleurs oculaires;2.3;M17.05.02;Douleurs oculaires;OK;OK;;;;;;
+Motif de recours médico secouriste;$.qualification.healthMotive;1.9;M60.94;Autres douleurs - Douleurs ORL (nez, gorge, oreilles);2.3;M17.05.03;Douleurs ORL (nez / gorge / oreilles);OK;OK;;;;;;
+Motif de recours médico secouriste;$.qualification.healthMotive;1.9;M60.96;Autres douleurs - Sans signe de gravité identifié;2.3;M17.05.04;Autres douleurs sans signe de gravité;OK;OK;;;;;;
+Motif de recours médico secouriste;$.qualification.healthMotive;1.9;M80.00;Accouchement / problème obstétrique;2.3;M18.00.00;Accouchement / problème obstétrique;OK;OK;;;;;;
+Motif de recours médico secouriste;$.qualification.healthMotive;1.9;M80.01;Accouchement réalisé ou imminent;2.3;M18.01.00;Accouchement réalisé ou imminent;OK;OK;;;;;;
+Motif de recours médico secouriste;$.qualification.healthMotive;1.9;M80.02;Accouchement réalisé ou imminent - Partie du bébé est visible;2.3;M18.01.01;Accouchement imminent avec bébé visible;OK;OK;;;;;;
+Motif de recours médico secouriste;$.qualification.healthMotive;1.9;M80.03;Accouchement réalisé ou imminent - Accouchement réalisé;2.3;M18.01.02;Accouchement réalisé;OK;OK;;;;;;
+Motif de recours médico secouriste;$.qualification.healthMotive;1.9;M80.04;Accouchement réalisé ou imminent - Sent le bébé descendre / Envie de pousser;2.3;M18.01.03;Accouchement imminent - Sent le bébé descendre ou envie de pousser;OK;OK;;;;;;
+Motif de recours médico secouriste;$.qualification.healthMotive;1.9;M80.05;Accouchement réalisé ou imminent - Contractions < 5 min avec ou sans perte des eaux;2.3;M18.01.04;Accouchement imminent - Contractions < 5 min avec ou sans perte des eaux;OK;OK;;;;;;
+Motif de recours médico secouriste;$.qualification.healthMotive;1.9;M80.06;Accouchement réalisé ou imminent - Contractions entre 5 et 10 min avec ou sans perte des eaux;2.3;M18.01.05;Accouchement imminent - Contractions entre 5 et 10 min avec ou sans perte des eaux;OK;OK;;;;;;
+Motif de recours médico secouriste;$.qualification.healthMotive;1.9;M80.07;Accouchement réalisé ou imminent - Perte des eaux;2.3;M18.01.06;Accouchement imminent - Perte des eaux;OK;OK;;;;;;
+Motif de recours médico secouriste;$.qualification.healthMotive;1.9;M80.08;Accouchement réalisé ou imminent - Contractions et hémorrgies;2.3;M18.01.07;Accouchement imminent - Contractions et hémorragies;OK;OK;;;;;;
+Motif de recours médico secouriste;$.qualification.healthMotive;1.9;M80.11;Autre problème obstétrical;2.3;M18.02.00;Autre problème obstétrical ;OK;OK;;;;;;
+Motif de recours médico secouriste;$.qualification.healthMotive;1.9;M80.12;Autre problème obstétrical - Saignement / hémorragie pour une grossesse;2.3;M18.02.01;Saignement / hémorragie au décours d'une grossesse;OK;OK;;;;;;
+Motif de recours médico secouriste;$.qualification.healthMotive;1.9;M80.13;Autre problème obstétrical - Douleurs abdominales de la femme enceinte;2.3;M18.02.02;Douleurs abdominales chez une femme enceinte;OK;OK;;;;;;
+Motif de recours médico secouriste;$.qualification.healthMotive;1.9;M80.14;Autre problème obstétrical - Saignement / hémorragie;2.3;M18.02.03;Autre problème obstétrical  avec saignement / hémorragie ;OK;OK;;;;;;
+Motif de recours médico secouriste;$.qualification.healthMotive;1.9;M80.15;Autre problème obstétrical - Anomalie de résultat biologique;2.3;M18.02.04;Problème obstétrical avec anomalie de résultat biologique;OK;OK;;;;;;
+Motif de recours médico secouriste;$.qualification.healthMotive;1.9;M80.19;Autre problème obstétrical - Autre problème obstétrical sans signe de gravité identifié;2.3;M18.02.05; Autre problème obstétrical sans signe de gravité;OK;OK;;;;;;
+Motif de recours médico secouriste;$.qualification.healthMotive;1.9;M90.00;Autres affections;2.3;M19.00.00;Autres affections;OK;OK;;;;;;
+Motif de recours médico secouriste;$.qualification.healthMotive;1.9;M90.01;Accident exposition aux risques biologiques;2.3;M19.01.00;Accident exposition aux risques biologiques;OK;OK;;;;;;
+Motif de recours médico secouriste;$.qualification.healthMotive;1.9;M90.11;Allergies;2.3;M19.02.00;Allergies;OK;OK;;;;;;
+Motif de recours médico secouriste;$.qualification.healthMotive;1.9;M90.12;Allergies - Avec gonflement du visage, du cou, modification de la voix;2.3;M19.02.01;Allergies avec gonflement du visage, du cou ou modification de la voix;OK;OK;;;;;;
+Motif de recours médico secouriste;$.qualification.healthMotive;1.9;M90.13;Allergies - Avec sensation de malaise/problème digestif;2.3;M19.02.02;Allergies - Avec sensation de malaise/problème digestif;OK;OK;;;;;;
+Motif de recours médico secouriste;$.qualification.healthMotive;1.9;M90.14;Allergies - Avec éruption généralisée;2.3;M19.02.03;Allergies avec éruption généralisée;OK;OK;;;;;;
+Motif de recours médico secouriste;$.qualification.healthMotive;1.9;M90.16;Allergies - Avec perte de connaissance initiale ou inconscience;2.3;M19.02.04;Allergies  avec perte de connaissance initiale ou altération de la inconscience;OK;OK;;;;;;
+Motif de recours médico secouriste;$.qualification.healthMotive;1.9;M90.17;Allergies - Avec difficultés respiratoires;2.3;M19.02.05;Allergies avec difficultés respiratoires;OK;OK;;;;;;
+Motif de recours médico secouriste;$.qualification.healthMotive;1.9;M90.19;Allergies - Allergie sans signe de gravité identifié;2.3;M19.02.06;Allergies sans signe de gravité;OK;OK;;;;;;
+Motif de recours médico secouriste;$.qualification.healthMotive;1.9;M90.21;Anomalie de la glycémie;2.3;M19.03.00;Anomalie de la glycémie;OK;OK;;;;;;
+Motif de recours médico secouriste;$.qualification.healthMotive;1.9;M90.31;Demande de conseil médical ou ordonnance;2.3;M19.04.00;Demande de conseil médical ou ordonnance;OK;OK;;;;;;
+Motif de recours médico secouriste;$.qualification.healthMotive;1.9;M90.41;Fièvre;2.3;M19.05.00;Fièvre;OK;OK;;;;;;
+Motif de recours médico secouriste;$.qualification.healthMotive;1.9;M90.51;Trouble digestif;2.3;M19.06.00;Trouble digestif;OK;OK;;;;;;
+Motif de recours médico secouriste;$.qualification.healthMotive;1.9;M90.52;Trouble digestif - Avec hémorragie digestive;2.3;M19.06.01;Trouble digestif avec hémorragie digestive;OK;OK;;;;;;
+Motif de recours médico secouriste;$.qualification.healthMotive;1.9;M90.53;Trouble digestif - Avec trouble digestif;2.3;M19.06.02;Trouble digestif avec trouble du transit (diarrhée / vomissement);OK;OK;;;;;;
+Motif de recours médico secouriste;$.qualification.healthMotive;1.9;M90.54;Trouble digestif - Problème de poche digestive;2.3;M19.06.03;Problème de poche digestive;OK;OK;;;;;;
+Motif de recours médico secouriste;$.qualification.healthMotive;1.9;M90.55;Trouble digestif - Sans douleur;2.3;M19.06.04;Trouble digestif sans douleur;OK;OK;;;;;;
+Motif de recours médico secouriste;$.qualification.healthMotive;1.9;M90.59;Trouble digestif - Troubles digestifs sans signe de gravité identifié;2.3;M19.06.05;Troubles digestifs sans signe de gravité;OK;OK;;;;;;
+Motif de recours médico secouriste;$.qualification.healthMotive;1.9;M90.61;Problème psychiatrique / social;2.3;M19.07.00;Problème psychiatrique / social;OK;OK;;;;;;
+Motif de recours médico secouriste;$.qualification.healthMotive;1.9;M90.62;Problème psychiatrique / social - Altération de l‘état général - misère physiologique et incurie;2.3;M19.07.01;Misère physiologique ou incurie;OK;OK;;;;;;
+Motif de recours médico secouriste;$.qualification.healthMotive;1.9;M90.63;Problème psychiatrique / social - Agitation, crise nerveuse, comportement violent;2.3;M19.07.02;Agitation / crise nerveuse / comportement violent;OK;OK;;;;;;
+Motif de recours médico secouriste;$.qualification.healthMotive;1.9;M90.64;Problème psychiatrique / social - Etat de manque - Sevrage;2.3;M19.07.03;Etat de manque / Sevrage;OK;OK;;;;;;
+Motif de recours médico secouriste;$.qualification.healthMotive;1.9;M90.65;Problème psychiatrique / social - Problème social ou sanitaire;2.3;M19.07.04;Problème social ou sanitaire;OK;OK;;;;;;
+Motif de recours médico secouriste;$.qualification.healthMotive;1.9;M90.71;Problème infectieux;2.3;M19.08.00;Problème infectieux;OK;OK;;;;;;
+Motif de recours médico secouriste;$.qualification.healthMotive;1.9;M98.00;Décès certain;2.3;M20.00.00;Décès certain;OK;OK;;;;;;
+Motif de recours médico secouriste;$.qualification.healthMotive;1.9;M98.01;Corps en décomposition;2.3;M20.01.00;Corps en décomposition;OK;OK;;;;;;
+Motif de recours médico secouriste;$.qualification.healthMotive;1.9;M98.11;Décés déclaré par un professionnel de santé;2.3;M20.02.00;Décés déclaré par un professionnel de santé;OK;OK;;;;;;
+Motif de recours médico secouriste;$.qualification.healthMotive;1.9;M98.21;Rigidité cadavérique certaine au niveau des membres et corps froid;2.3;M20.03.00;Rigidité cadavérique et corps froid;OK;OK;;;;;;
+Motif de recours médico secouriste;$.qualification.healthMotive;1.9;M98.31;Tête détachée;2.3;M20.04.00;Tête séparée du tronc;OK;OK;;;;;;
+Motif de recours médico secouriste;$.qualification.healthMotive;2.3;M08.00.00;Personne inconsciente ;1.9;M22.00;Personne inconsciente;OK;OK;;;;;;
+Motif de recours médico secouriste;$.qualification.healthMotive;2.3;M08.01.00;Personne en arrêt ventilatoire;1.9;M22.01;Pas de mouvement ventilatoire;OK;OK;;;;;;
+Motif de recours médico secouriste;$.qualification.healthMotive;2.3;M08.02.00;Personne en arrêt cardio-respiratoire;1.9;M22.11;Arrêt cardio-respiratoire;OK;OK;;;;;;
+Motif de recours médico secouriste;$.qualification.healthMotive;2.3;M08.03.00;Personne inconsciente qui respire;1.9;M22.21;Inconscient qui respire;OK;OK;;;;;;
+Motif de recours médico secouriste;$.qualification.healthMotive;2.3;M09.00.00;Hémorragies / Saignements ;1.9;M24.00;Hémorragies / Saignements;OK;OK;;;;;;
+Motif de recours médico secouriste;$.qualification.healthMotive;2.3;M09.01.00;Hémorragie ne pouvant être stoppée;1.9;M24.01;Hémorragie ne pouvant être stoppée;OK;OK;;;;;;
+Motif de recours médico secouriste;$.qualification.healthMotive;2.3;M09.01.01;Epitaxis non stoppée par compression;1.9;M24.02;Hémorragie ne pouvant être stoppée - Epistaxis non stoppée par la compression;OK;OK;;;;;;
+Motif de recours médico secouriste;$.qualification.healthMotive;2.3;M09.02.00;Hémorragie extériorisée;1.9;M24.21;Hémorragie extériorisée;OK;OK;;;;;;
+Motif de recours médico secouriste;$.qualification.healthMotive;2.3;M09.02.01;Hémorragie digestive (haute ou basse) extériorisée;1.9;M24.25;Hémorragie extériorisée - Hémorragie digestive (haute ou basse);OK;OK;;;;;;
+Motif de recours médico secouriste;$.qualification.healthMotive;2.3;M09.02.02;Hémorragie extériorisée avec malaise ;1.9;M24.26;Hémorragie extériorisée - Malaise;OK;OK;;;;;;
+Motif de recours médico secouriste;$.qualification.healthMotive;2.3;M09.02.03;Crache du sang hémoptysie;1.9;M24.27;Hémorragie extériorisée - Crache du sang en toussant;OK;OK;;;;;;
+Motif de recours médico secouriste;$.qualification.healthMotive;2.3;M09.02.04;Saignement stoppé par compression;1.9;M24.28;Hémorragie extériorisée - Saignement peut être stoppé par compression;OK;OK;;;;;;
+Motif de recours médico secouriste;$.qualification.healthMotive;2.3;M09.02.05;Epistaxis stoppée par compression;1.9;M24.29;Hémorragie extériorisée - Epistaxis stoppée par compression;OK;OK;;;;;;
+Motif de recours médico secouriste;$.qualification.healthMotive;2.3;M09.03.00;Saignements bénins;1.9;M24.91;Saignements bénins;OK;OK;;;;;;
+Motif de recours médico secouriste;$.qualification.healthMotive;2.3;M09.03.01;Saignement bénin sans signe de gravité identifié;1.9;M24.92;Saignements bénins - Saignement sans signe de gravité identifié;OK;OK;;;;;;
+Motif de recours médico secouriste;$.qualification.healthMotive;2.3;M10.00.00;Problème circulatoire;1.9;M30.00;Circulatoire;OK;OK;;;;;;
+Motif de recours médico secouriste;$.qualification.healthMotive;2.3;M10.01.00;Palpitations;1.9;M30.61;Palpitations;OK;OK;;;;;;
+Motif de recours médico secouriste;$.qualification.healthMotive;2.3;M10.02.00;Autres troubles circulatoires;1.9;M30.00;Circulatoire;OK;OK;;;;;;
+Motif de recours médico secouriste;$.qualification.healthMotive;2.3;M10.02.01;Patient/victime choquée par défibrillateur implanté;1.9;M30.92;Autres troubles - Victime déjà choquée par un DAI;OK;OK;;;;;;
+Motif de recours médico secouriste;$.qualification.healthMotive;2.3;M10.02.02;Bradycardie < 50 ou tachycardie > 150;1.9;M30.93;Autres troubles - Fréquence cardiaque < 50 ou > 150;OK;OK;;;;;;
+Motif de recours médico secouriste;$.qualification.healthMotive;2.3;M10.02.03;Pression Artérielle < 90 mmHg;1.9;M30.95;Autres troubles - Tension artérielle < 90 mm Hg;OK;OK;;;;;;
+Motif de recours médico secouriste;$.qualification.healthMotive;2.3;M10.02.04;Pression Artérielle > 160 mmHg;1.9;M30.96;Autres troubles - Tension artérielle > 160 mm Hg;OK;OK;;;;;;
+Motif de recours médico secouriste;$.qualification.healthMotive;2.3;M10.02.05;Autre trouble sans signe de gravité;1.9;M30.97;Autres troubles - Autre trouble sans signe de gravité identifié;OK;OK;;;;;;
+Motif de recours médico secouriste;$.qualification.healthMotive;2.3;M11.00.00;Problème respiratoire;1.9;M31.11 ;Difficultés respiratoires;OK;OK;;;;;;
+Motif de recours médico secouriste;$.qualification.healthMotive;2.3;M11.01.00;Détresse respiratoire;1.9;M31.01;Détresse respiratoire;OK;OK;;;;;;
+Motif de recours médico secouriste;$.qualification.healthMotive;2.3;M11.01.01;Détresse respiratoire avec asphyxie;1.9;M31.02;Détresse respiratoire - Etat asphyxique (moins de 4 syllabes ou mots courts, cyanose), ou obstruction complète;OK;OK;;;;;;
+Motif de recours médico secouriste;$.qualification.healthMotive;2.3;M11.01.02;Epuisement respiratoire chez un nourrisson ;1.9;M31.03;Détresse respiratoire - Epuisement respiratoire chez un nourrisson ou signes de lutte;OK;OK;;;;;;
+Motif de recours médico secouriste;$.qualification.healthMotive;2.3;M11.02.00;Difficultés respiratoires;1.9;M31.11 ;Difficultés respiratoires;OK;OK;;;;;;
+Motif de recours médico secouriste;$.qualification.healthMotive;2.3;M11.02.01;Respiration bruyante;1.9;M31.12;Difficultés respiratoires - Respiration bruyante;OK;OK;;;;;;
+Motif de recours médico secouriste;$.qualification.healthMotive;2.3;M11.02.02;Difficultés respiratoires avec sueurs ou altération de conscience;1.9;M31.13;Difficultés respiratoires - Sueurs et/ou troubles de conscience;OK;OK;;;;;;
+Motif de recours médico secouriste;$.qualification.healthMotive;2.3;M11.02.03;Difficultés respiratoires sans signe de gravité;1.9;M31.19;Difficultés respiratoires - Difficultés respiratoires sans signe de gravité identifié;OK;OK;;;;;;
+Motif de recours médico secouriste;$.qualification.healthMotive;2.3;M11.03.00;Autres problèmes respiratoires;1.9;M31.91;Autres problème respiratoire;OK;OK;;;;;;
+Motif de recours médico secouriste;$.qualification.healthMotive;2.3;M11.03.01;Problème isolé d'appareillage respiratoire ou canule ;1.9;M31.92;Autres problème respiratoire - Problème isolé d appareillage respiratoire ou canule;OK;OK;;;;;;
+Motif de recours médico secouriste;$.qualification.healthMotive;2.3;M11.03.02;Corps étranger expulsé des poumons;1.9;M31.93;Autres problème respiratoire - Corps étranger expulsé;OK;OK;;;;;;
+Motif de recours médico secouriste;$.qualification.healthMotive;2.3;M11.03.03;Problème respiratoire avec obstruction partielle;1.9;M31.94;Autres problème respiratoire - Obstruction partielle;OK;OK;;;;;;
+Motif de recours médico secouriste;$.qualification.healthMotive;2.3;M11.03.04;Autres problème respiratoire sans signe de gravité;1.9;M31.99;Autres problème respiratoire - Autres problème respiratoire sans signe de gravité identifié;OK;OK;;;;;;
+Motif de recours médico secouriste;$.qualification.healthMotive;2.3;M12.00.00;Problème neurologique;1.9;M32.00;Neurologie;OK;OK;;;;;;
+Motif de recours médico secouriste;$.qualification.healthMotive;2.3;M12.01.00;Suspicion AVC / AIT;1.9;M32.01;Suspicion AVC / AIT;OK;OK;;;;;;
+Motif de recours médico secouriste;$.qualification.healthMotive;2.3;M12.01.01;Suspicion AVC / AIT avec trouble de conscience ;1.9;M32.02;Suspicion AVC / AIT - Avec troubles de la conscience;OK;OK;;;;;;
+Motif de recours médico secouriste;$.qualification.healthMotive;2.3;M12.01.02;Suspicion AVC / AIT sans céphalée ou vomissement ni trouble de la conscience;1.9;M32.01;Suspicion AVC / AIT;OK;OK;;;;;;
+Motif de recours médico secouriste;$.qualification.healthMotive;2.3;M12.01.03;Suspicion AVC / AIT avec disparition des signes d'AVC à l'appel;1.9;M32.05;Suspicion AVC / AIT - Avec disparition des signes associés à l‘AVC au moment de l‘appel;OK;OK;;;;;;
+Motif de recours médico secouriste;$.qualification.healthMotive;2.3;M12.02.00;Convulsions persistantes;1.9;M32.11;Convulsions persistantes;OK;OK;;;;;;
+Motif de recours médico secouriste;$.qualification.healthMotive;2.3;M12.03.00;Convulsion ;1.9;M32.21;Convulsions;OK;OK;;;;;;
+Motif de recours médico secouriste;$.qualification.healthMotive;2.3;M12.03.01;Convulsions chez une femme enceinte ;1.9;M32.22;Convulsions - Chez la femme enceinte;OK;OK;;;;;;
+Motif de recours médico secouriste;$.qualification.healthMotive;2.3;M12.03.02;Convulsions avec fièvre chez l'enfant;1.9;M32.25;Convulsions - Hyperthermiques de l‘enfant;OK;OK;;;;;;
+Motif de recours médico secouriste;$.qualification.healthMotive;2.3;M12.03.03;En cours de réveil après convulsions;1.9;M32.24;Convulsions - Réveil après convulsions;OK;OK;;;;;;
+Motif de recours médico secouriste;$.qualification.healthMotive;2.3;M12.04.00;Trouble de la conscience ;1.9;M32.31;Trouble de la conscience;OK;OK;;;;;;
+Motif de recours médico secouriste;$.qualification.healthMotive;2.3;M12.04.01;Trouble de la conscience chez un diabétique;1.9;M32.32;Trouble de la conscience - Chez le diabétique;OK;OK;;;;;;
+Motif de recours médico secouriste;$.qualification.healthMotive;2.3;M12.04.02;Trouble de la conscience avec perte de connaissance initiale;1.9;M32.34;Trouble de la conscience - Avec perte de connaissance initiale;OK;OK;;;;;;
+Motif de recours médico secouriste;$.qualification.healthMotive;2.3;M12.04.03;Somnolent et capable de parler ou de répondre à des ordres simples;1.9;M32.35;Trouble de la conscience - Somnolent et capable de parler ou de répondre à des ordres simples;OK;OK;;;;;;
+Motif de recours médico secouriste;$.qualification.healthMotive;2.3;M12.04.04;Confusion, désorientation;1.9;M32.36;Trouble de la conscience - Confusion, désorientation;OK;OK;;;;;;
+Motif de recours médico secouriste;$.qualification.healthMotive;2.3;M12.04.05;Autre trouble de la conscience sans signe de gravité;1.9;M32.39;Trouble de la conscience - Trouble de la conscience sans signe de gravité identifié;OK;OK;;;;;;
+Motif de recours médico secouriste;$.qualification.healthMotive;2.3;M12.05.00;Malaise;1.9;M32.51;Malaise;OK;OK;;;;;;
+Motif de recours médico secouriste;$.qualification.healthMotive;2.3;M12.05.01;Malaise sans signe de gravité;1.9;M32.57;Malaise - Malaise sans signe de gravité identifié;OK;OK;;;;;;
+Motif de recours médico secouriste;$.qualification.healthMotive;2.3;M12.05.02;Malaise au cours d'un effort;1.9;M32.52;Malaise - Malaise d effort;OK;OK;;;;;;
+Motif de recours médico secouriste;$.qualification.healthMotive;2.3;M12.05.03;Malaise avec perte de connaissance initiale;1.9;M32.54;Malaise - Avec perte de connaissance initiale;OK;OK;;;;;;
+Motif de recours médico secouriste;$.qualification.healthMotive;2.3;M12.05.04;Malaise avec trouble de la conscience;1.9;M32.55;Malaise - Avec trouble de la conscience;OK;OK;;;;;;
+Motif de recours médico secouriste;$.qualification.healthMotive;2.3;M12.06.00;Autre motif neurologique ;1.9;M32.91;Autre motif neurologique;OK;OK;;;;;;
+Motif de recours médico secouriste;$.qualification.healthMotive;2.3;M12.06.01;Céphalées isolées;1.9;M32.92;Autre motif neurologique - Céphalées;OK;OK;;;;;;
+Motif de recours médico secouriste;$.qualification.healthMotive;2.3;M12.06.02;Céphalées avec vomissement;1.9;M32.95;Autre motif neurologique - Céphalées avec vomissement;OK;OK;;;;;;
+Motif de recours médico secouriste;$.qualification.healthMotive;2.3;M12.06.03;Autre motif neurologique sans signe de gravité;1.9;M32.99;Autre motif neurologique - Autre motif neurologique sans signe de gravité identifié;OK;OK;;;;;;
+Motif de recours médico secouriste;$.qualification.healthMotive;2.3;M13.00.00;Traumatisme;1.9;M41.00;Traumatisme;OK;OK;;;;;;
+Motif de recours médico secouriste;$.qualification.healthMotive;2.3;M13.01.00;Personne restant à terre suite à une chute;1.9;M41.01;Personne restant à terre suite à une chute;OK;OK;;;;;;
+Motif de recours médico secouriste;$.qualification.healthMotive;2.3;M13.02.00;Polytraumatisme / traumatisme sévère;1.9;M41.11;Suspicion de victime polytraumatisé;OK;OK;;;;;;
+Motif de recours médico secouriste;$.qualification.healthMotive;2.3;M13.03.00;Traumatisme tête / cou;1.9;M41.21;Traumatisme tête / cou;OK;OK;;;;;;
+Motif de recours médico secouriste;$.qualification.healthMotive;2.3;M13.03.01;Traumatisme tête / cou avec perte de connaissance initiale ou troubles de la conscience;1.9;M41.22;Traumatisme tête - cou - Avec perte de connaissance ou troubles de la la conscience;OK;OK;;;;;;
+Motif de recours médico secouriste;$.qualification.healthMotive;2.3;M13.03.02;Traumatisme tête / cou sans signe de gravité;1.9;M41.29;Traumatisme tête - cou - Trauma tête / cou sans signe de gravité;OK;OK;;;;;;
+Motif de recours médico secouriste;$.qualification.healthMotive;2.3;M13.04.00;Traumatisme thorax;1.9;M41.31;Traumatisme thorax;OK;OK;;;;;;
+Motif de recours médico secouriste;$.qualification.healthMotive;2.3;M13.04.01;Traumatisme thorax avec gêne respiratoire;1.9;M41.32;Traumatisme thorax avec gêne respiratoire;OK;OK;;;;;;
+Motif de recours médico secouriste;$.qualification.healthMotive;2.3;M13.04.02;Traumatisme thorax sans signe de gravité;1.9;M41.39;Traumatisme thorax sans signe de gravité;OK;OK;;;;;;
+Motif de recours médico secouriste;$.qualification.healthMotive;2.3;M13.05.00;Traumatisme abdomen / bassin;1.9;M41.32;Traumatisme abdomen / bassin;OK;OK;;;;;;
+Motif de recours médico secouriste;$.qualification.healthMotive;2.3;M13.05.01;Traumatisme abdomen / bassin violent;1.9;M41.42;Traumatisme abdomen / bassin violent;OK;OK;;;;;;
+Motif de recours médico secouriste;$.qualification.healthMotive;2.3;M13.05.02;Traumatisme abdomen / bassin sans signe de gravité;1.9;M41.49;Traumatisme abdomen / bassin sans signe de gravité;OK;OK;;;;;;
+Motif de recours médico secouriste;$.qualification.healthMotive;2.3;M13.06.00;Traumatisme membres;1.9;M41.51;Traumatisme membres;OK;OK;;;;;;
+Motif de recours médico secouriste;$.qualification.healthMotive;2.3;M13.06.01;Traumatisme membre avec amputation;1.9;M41.52;Traumatisme membre avec amputation;OK;OK;;;;;;
+Motif de recours médico secouriste;$.qualification.healthMotive;2.3;M13.06.02;Fracture ouverte de membre;1.9;M41.53;Fracture ouverte de membre;OK;OK;;;;;;
+Motif de recours médico secouriste;$.qualification.healthMotive;2.3;M13.06.03;Fracture fermée de membre;1.9;M41.54;Fracture fermée de membre;OK;OK;;;;;;
+Motif de recours médico secouriste;$.qualification.healthMotive;2.3;M13.06.04;Traumatisme avec déformation de membre;1.9;M41.55;Traumatisme membres - déformation;OK;OK;;;;;;
+Motif de recours médico secouriste;$.qualification.healthMotive;2.3;M13.06.05;Traumatisme de membres sans signe de gravité;1.9;M41.59;Traumatisme membres - Traumatisme de membres sans signe de gravité;OK;OK;;;;;;
+Motif de recours médico secouriste;$.qualification.healthMotive;2.3;M13.07.00;Traumatisme doigts - orteils;1.9;M41.61;Traumatisme doigts - orteils;OK;OK;;;;;;
+Motif de recours médico secouriste;$.qualification.healthMotive;2.3;M13.07.01;Traumatisme doigts / orteils avec amputation;1.9;M41.62;Traumatisme doigts - orteils - Amputation;OK;OK;;;;;;
+Motif de recours médico secouriste;$.qualification.healthMotive;2.3;M13.07.02;Fracture ouverte de doigts / orteils ;1.9;M41.64;Traumatisme doigts - orteils - Fracture ouverte;OK;OK;;;;;;
+Motif de recours médico secouriste;$.qualification.healthMotive;2.3;M13.07.03;Fracture fermée doigts / orteils ;1.9;M41.65;Traumatisme doigts - orteils - Fracture fermée;OK;OK;;;;;;
+Motif de recours médico secouriste;$.qualification.healthMotive;2.3;M13.07.04;Traumatisme doigts / orteils  avec déformation;1.9;M41.66;Traumatisme doigts - orteils - Déformation;OK;OK;;;;;;
+Motif de recours médico secouriste;$.qualification.healthMotive;2.3;M13.07.05;Traumatisme doigts / orteils  sans signe de gravité;1.9;M41.69;Traumatisme doigts - orteils - Traumatisme de doigt - orteil sans signe de gravité;OK;OK;;;;;;
+Motif de recours médico secouriste;$.qualification.healthMotive;2.3;M14.00.00;Plaies;1.9;M45.00;Plaies;OK;OK;;;;;;
+Motif de recours médico secouriste;$.qualification.healthMotive;2.3;M14.01.00;Plaie pénétrante;1.9;M45.01;Pénétrante;OK;OK;;;;;;
+Motif de recours médico secouriste;$.qualification.healthMotive;2.3;M14.01.01;Plaie pénétrante étendue;1.9;M45.02;Etendue;OK;OK;;;;;;
+Motif de recours médico secouriste;$.qualification.healthMotive;2.3;M14.01.02;Plaies pénétrantes multiples;1.9;M45.03;Multiples;OK;OK;;;;;;
+Motif de recours médico secouriste;$.qualification.healthMotive;2.3;M14.01.03;Plaie grave du crâne (scalp);1.9;M45.05;Plaie grave du crâne (scalp);OK;OK;;;;;;
+Motif de recours médico secouriste;$.qualification.healthMotive;2.3;M14.01.04;Plaie grave du visage;1.9;M45.06;Plaie grave du visage;OK;OK;;;;;;
+Motif de recours médico secouriste;$.qualification.healthMotive;2.3;M14.01.05;Plaie grave du cou;1.9;M45.07;Plaie grave du cou;OK;OK;;;;;;
+Motif de recours médico secouriste;$.qualification.healthMotive;2.3;M14.01.06;Plaie grave du thorax - abdomen;1.9;M45.08;Plaie grave du thorax - abdomen;OK;OK;;;;;;
+Motif de recours médico secouriste;$.qualification.healthMotive;2.3;M14.01.07;Plaie grave avec pâleur/soif/prostration;1.9;M45.09;Pâleur, soif, prostation;OK;OK;;;;;;
+Motif de recours médico secouriste;$.qualification.healthMotive;2.3;M14.02.00;Morsure;1.9;M45.31;Morsure;OK;OK;;;;;;
+Motif de recours médico secouriste;$.qualification.healthMotive;2.3;M14.02.01;Morsure grave;1.9;M45.32;Morsure - Morsure grave;OK;OK;;;;;;
+Motif de recours médico secouriste;$.qualification.healthMotive;2.3;M14.02.02;Morsure sans signe de gravité;1.9;M45.33;Morsure - Morsure sans signe de gravité;OK;OK;;;;;;
+Motif de recours médico secouriste;$.qualification.healthMotive;2.3;M15.00.00;Brûlures;1.9;M46.00;Brûlures;OK;OK;;;;;;
+Motif de recours médico secouriste;$.qualification.healthMotive;2.3;M15.01.00;Brûlure thermique;1.9;M46.01;Brûlure thermique;OK;OK;;;;;;
+Motif de recours médico secouriste;$.qualification.healthMotive;2.3;M15.01.01;Brûlure thermique grave (étendue / circulaire / tronc / face / cou);1.9;M46.02;Brûlure thermique - Brûlure étendue / circulaire ou tronc / face / cou;OK;OK;;;;;;
+Motif de recours médico secouriste;$.qualification.healthMotive;2.3;M15.01.02;Brûlure thermique à l'œil;1.9;M46.03;Brûlure thermique - Brûlure à l‘oeil;OK;OK;;;;;;
+Motif de recours médico secouriste;$.qualification.healthMotive;2.3;M15.01.03;Brûlure thermique sans signe de gravité;1.9;M46.09;Brûlure thermique - Brûlure thermique sans signe de gravité identifié;OK;OK;;;;;;
+Motif de recours médico secouriste;$.qualification.healthMotive;2.3;M15.02.00;Brûlure chimique;1.9;M46.11;Brûlure chimique;OK;OK;;;;;;
+Motif de recours médico secouriste;$.qualification.healthMotive;2.3;M15.02.01;Brûlure chimique grave (étendue / circulaire / tronc / face / cou);1.9;M46.12;Brûlure chimique - Brûlure étendue / circulaire ou tronc / face / cou;OK;OK;;;;;;
+Motif de recours médico secouriste;$.qualification.healthMotive;2.3;M15.02.02;Brûlure à l'œil;1.9;M46.13;Brûlure chimique - Brûlure à l‘oeil;OK;OK;;;;;;
+Motif de recours médico secouriste;$.qualification.healthMotive;2.3;M15.02.03;Brûlure chimique sans signe de gravité;1.9;M46.19;Brûlure chimique - Brûlure chimique sans signe de gravité identifié;OK;OK;;;;;;
+Motif de recours médico secouriste;$.qualification.healthMotive;2.3;M15.03.00;Gelure;1.9;M46.21;Gelure;OK;OK;;;;;;
+Motif de recours médico secouriste;$.qualification.healthMotive;2.3;M15.03.01;Gelure grave;1.9;M46.22;Gelure - Gelure grave;OK;OK;;;;;;
+Motif de recours médico secouriste;$.qualification.healthMotive;2.3;M15.03.02;Gelure sans signe de gravité;1.9;M46.29;Gelure - Gelure sans signe de gravité identifié;OK;OK;;;;;;
+Motif de recours médico secouriste;$.qualification.healthMotive;2.3;M16.00.00;Intoxication;1.9;M50.00;Intoxication;OK;OK;;;;;;
+Motif de recours médico secouriste;$.qualification.healthMotive;2.3;M16.01.00;Intoxication au CO / fumées;1.9;M50.11;Intoxication au CO / fumées;OK;OK;;;;;;
+Motif de recours médico secouriste;$.qualification.healthMotive;2.3;M16.01.01;Intoxication au CO / fumées avec convulsions / troubles de la conscience;1.9;M50.12;Intoxication au CO / fumées - Avec convulsions / troubles de la conscience;OK;OK;;;;;;
+Motif de recours médico secouriste;$.qualification.healthMotive;2.3;M16.01.02;Intoxication au CO / fumées avec vomissements, céphalées;1.9;M50.15;Intoxication au CO / fumées - Vomissements, céphalées;OK;OK;;;;;;
+Motif de recours médico secouriste;$.qualification.healthMotive;2.3;M16.01.03;Intoxication au CO / fumées sans signe de gravité;1.9;M50.16;Intoxication au CO / fumées - Sans signe de gravité identifié;OK;OK;;;;;;
+Motif de recours médico secouriste;$.qualification.healthMotive;2.3;M16.02.00;Intoxication éthylique / prise de stupéfiants ;1.9;M50.21;Intoxication éthylique ou prise de stupéfiants;OK;OK;;;;;;
+Motif de recours médico secouriste;$.qualification.healthMotive;2.3;M16.02.01;Intoxication éthylique / prise de stupéfiants avec convulsions ou coma;1.9;M50.22;Intoxication éthylique ou prise de stupéfiants - Convulsions et/ou coma;OK;OK;;;;;;
+Motif de recours médico secouriste;$.qualification.healthMotive;2.3;M16.02.02;Intoxication éthylique / prise de stupéfiants avec somnolence;1.9;M50.25;Intoxication éthylique ou prise de stupéfiants - Somnolence;OK;OK;;;;;;
+Motif de recours médico secouriste;$.qualification.healthMotive;2.3;M16.02.03;Intoxication éthylique / prise de stupéfiants sans signe de gravité;1.9;M50.29;Intoxication éthylique ou prise de stupéfiants - Sans signe de gravité identifié;OK;OK;;;;;;
+Motif de recours médico secouriste;$.qualification.healthMotive;2.3;M16.03.00;Intoxication médicamenteuse ;1.9;M50.31;Médicamenteuse;OK;OK;;;;;;
+Motif de recours médico secouriste;$.qualification.healthMotive;2.3;M16.03.01;Intoxication médicamenteuse avec convulsions ou coma;1.9;M50.32;Médicamenteuse - Convulsions et/ou coma;OK;OK;;;;;;
+Motif de recours médico secouriste;$.qualification.healthMotive;2.3;M16.03.02;Intoxication médicamenteuse avec détresse respiratoire ;1.9;M50.33;Médicamenteuse - Détresse respiratoire;OK;OK;;;;;;
+Motif de recours médico secouriste;$.qualification.healthMotive;2.3;M16.03.03;Intoxication médicamenteuse avec somnolence;1.9;M50.35;Médicamenteuse - Somnolence;OK;OK;;;;;;
+Motif de recours médico secouriste;$.qualification.healthMotive;2.3;M16.03.04;Intoxication médicamenteuse sans signe de gravité;1.9;M50.39;Médicamenteuse - Sans signe de gravité identifié;OK;OK;;;;;;
+Motif de recours médico secouriste;$.qualification.healthMotive;2.3;M16.04.00;Intoxication chimique / venimeuse;1.9;M50.51;Chimiques / venimeuses;OK;OK;;;;;;
+Motif de recours médico secouriste;$.qualification.healthMotive;2.3;M16.04.01;Intoxication chimique / venimeuse avec convulsions / troubles de la conscience;1.9;M50.52;Chimiques / venimeuses - Avec convulsions / troubles de la conscience;OK;OK;;;;;;
+Motif de recours médico secouriste;$.qualification.healthMotive;2.3;M16.04.02;Intoxication chimique / venimeuse avec détresse respiratoire ou toux;1.9;M50.53;Chimiques / venimeuses - Détresse respiratoire et/ou toux;OK;OK;;;;;;
+Motif de recours médico secouriste;$.qualification.healthMotive;2.3;M16.04.03;Intoxication chimique / venimeuse sans signe de gravité;1.9;M50.54;Chimiques / venimeuses - Sans signe de gravité identifié;OK;OK;;;;;;
+Motif de recours médico secouriste;$.qualification.healthMotive;2.3;M17.00.00;Douleurs;1.9;M60.00;Douleurs;OK;OK;;;;;;
+Motif de recours médico secouriste;$.qualification.healthMotive;2.3;M17.01.00;Céphalées;1.9;M60.01;Céphalées;OK;OK;;;;;;
+Motif de recours médico secouriste;$.qualification.healthMotive;2.3;M17.01.01;Céphalées avec troubles de conscience;1.9;M60.03;Céphalées - Avec troubles de conscience;OK;OK;;;;;;
+Motif de recours médico secouriste;$.qualification.healthMotive;2.3;M17.01.02;Céphalées chez la femme enceinte;1.9;M60.05;Céphalées - Céphalées chez la femme enceinte;OK;OK;;;;;;
+Motif de recours médico secouriste;$.qualification.healthMotive;2.3;M17.01.03;Céphalées sans signe de gravité;1.9;M60.08;Céphalées - Sans signe de gravité identifiée;OK;OK;;;;;;
+Motif de recours médico secouriste;$.qualification.healthMotive;2.3;M17.02.00;Douleurs abdominales ;1.9;M60.21;Douleurs abdominales;OK;OK;;;;;;
+Motif de recours médico secouriste;$.qualification.healthMotive;2.3;M17.02.01;Douleurs abdominales sans signe de gravité;1.9;M60.26;Douleurs abdominales - Sans signe de gravité identifiée;OK;OK;;;;;;
+Motif de recours médico secouriste;$.qualification.healthMotive;2.3;M17.03.00;Douleur thoracique ;1.9;M60.31;Douleur thoracique;OK;OK;;;;;;
+Motif de recours médico secouriste;$.qualification.healthMotive;2.3;M17.03.01;Douleur thoracique  -  cas d'usage n°1;1.9;M60.31;Douleur thoracique;OK;OK;;;;;;
+Motif de recours médico secouriste;$.qualification.healthMotive;2.3;M17.03.02;Douleur thoracique  -  cas d'usage n°2;1.9;M60.31;Douleur thoracique;OK;OK;;;;;;
+Motif de recours médico secouriste;$.qualification.healthMotive;2.3;M17.03.03;Douleur thoracique  - cas d'usage n°3;1.9;M60.31;Douleur thoracique;OK;OK;;;;;;
+Motif de recours médico secouriste;$.qualification.healthMotive;2.3;M17.04.00;Douleurs ostéoarticulaires ;1.9;M60.51;Douleurs ostéoarticulaires;OK;OK;;;;;;
+Motif de recours médico secouriste;$.qualification.healthMotive;2.3;M17.04.01;Douleurs ostéoarticulaires ou de membre;1.9;M60.53;Douleurs ostéoarticulaires - Douleur de membre;OK;OK;;;;;;
+Motif de recours médico secouriste;$.qualification.healthMotive;2.3;M17.04.02;Douleur ostéoarticulaire sans signe de gravité;1.9;M50.59;Douleurs ostéoarticulaires - Douleur ostéoarticulaire sans signe de gravité identifié;OK;OK;;;;;;
+Motif de recours médico secouriste;$.qualification.healthMotive;2.3;M17.05.00;Autres douleurs ;1.9;M60.91;Autres douleurs;OK;OK;;;;;;
+Motif de recours médico secouriste;$.qualification.healthMotive;2.3;M17.05.01;Douleurs dentaires;1.9;M60.92;Autres douleurs - Douleurs dentaires;OK;OK;;;;;;
+Motif de recours médico secouriste;$.qualification.healthMotive;2.3;M17.05.02;Douleurs oculaires;1.9;M60.93;Autres douleurs - Douleurs oculaires;OK;OK;;;;;;
+Motif de recours médico secouriste;$.qualification.healthMotive;2.3;M17.05.03;Douleurs ORL (nez / gorge / oreilles);1.9;M60.94;Autres douleurs - Douleurs ORL (nez, gorge, oreilles);OK;OK;;;;;;
+Motif de recours médico secouriste;$.qualification.healthMotive;2.3;M17.05.04;Autres douleurs sans signe de gravité;1.9;M60.96;Autres douleurs - Sans signe de gravité identifié;OK;OK;;;;;;
+Motif de recours médico secouriste;$.qualification.healthMotive;2.3;M18.00.00;Accouchement / problème obstétrique;1.9;M80.00;Accouchement / problème obstétrique;OK;OK;;;;;;
+Motif de recours médico secouriste;$.qualification.healthMotive;2.3;M18.01.00;Accouchement réalisé ou imminent;1.9;M80.01;Accouchement réalisé ou imminent;OK;OK;;;;;;
+Motif de recours médico secouriste;$.qualification.healthMotive;2.3;M18.01.01;Accouchement imminent avec bébé visible;1.9;M80.02;Accouchement réalisé ou imminent - Partie du bébé est visible;OK;OK;;;;;;
+Motif de recours médico secouriste;$.qualification.healthMotive;2.3;M18.01.02;Accouchement réalisé;1.9;M80.01;Accouchement réalisé ou imminent;OK;OK;;;;;;
+Motif de recours médico secouriste;$.qualification.healthMotive;2.3;M18.01.03;Accouchement imminent - Sent le bébé descendre ou envie de pousser;1.9;M80.04;Accouchement réalisé ou imminent - Sent le bébé descendre / Envie de pousser;OK;OK;;;;;;
+Motif de recours médico secouriste;$.qualification.healthMotive;2.3;M18.01.04;Accouchement imminent - Contractions < 5 min avec ou sans perte des eaux;1.9;M80.05;Accouchement réalisé ou imminent - Contractions < 5 min avec ou sans perte des eaux;OK;OK;;;;;;
+Motif de recours médico secouriste;$.qualification.healthMotive;2.3;M18.01.05;Accouchement imminent - Contractions entre 5 et 10 min avec ou sans perte des eaux;1.9;M80.06;Accouchement réalisé ou imminent - Contractions entre 5 et 10 min avec ou sans perte des eaux;OK;OK;;;;;;
+Motif de recours médico secouriste;$.qualification.healthMotive;2.3;M18.01.06;Accouchement imminent - Perte des eaux;1.9;M80.07;Accouchement réalisé ou imminent - Perte des eaux;OK;OK;;;;;;
+Motif de recours médico secouriste;$.qualification.healthMotive;2.3;M18.01.07;Accouchement imminent - Contractions et hémorragies;1.9;M80.08;Accouchement réalisé ou imminent - Contractions et hémorrgies;OK;OK;;;;;;
+Motif de recours médico secouriste;$.qualification.healthMotive;2.3;M18.02.00;Autre problème obstétrical ;1.9;M80.11;Autre problème obstétrical;OK;OK;;;;;;
+Motif de recours médico secouriste;$.qualification.healthMotive;2.3;M18.02.01;Saignement / hémorragie au décours d'une grossesse;1.9;M80.12;Autre problème obstétrical - Saignement / hémorragie pour une grossesse;OK;OK;;;;;;
+Motif de recours médico secouriste;$.qualification.healthMotive;2.3;M18.02.02;Douleurs abdominales chez une femme enceinte;1.9;M80.13;Autre problème obstétrical - Douleurs abdominales de la femme enceinte;OK;OK;;;;;;
+Motif de recours médico secouriste;$.qualification.healthMotive;2.3;M18.02.03;Autre problème obstétrical  avec saignement / hémorragie ;1.9;M80.14;Autre problème obstétrical - Saignement / hémorragie;OK;OK;;;;;;
+Motif de recours médico secouriste;$.qualification.healthMotive;2.3;M18.02.04;Problème obstétrical avec anomalie de résultat biologique;1.9;M80.15;Autre problème obstétrical - Anomalie de résultat biologique;OK;OK;;;;;;
+Motif de recours médico secouriste;$.qualification.healthMotive;2.3;M18.02.05; Autre problème obstétrical sans signe de gravité;1.9;M80.19;Autre problème obstétrical - Autre problème obstétrical sans signe de gravité identifié;OK;OK;;;;;;
+Motif de recours médico secouriste;$.qualification.healthMotive;2.3;M19.00.00;Autres affections;1.9;M90.00;Autres affections;OK;OK;;;;;;
+Motif de recours médico secouriste;$.qualification.healthMotive;2.3;M19.01.00;Accident exposition aux risques biologiques;1.9;M90.01;Accident exposition aux risques biologiques;OK;OK;;;;;;
+Motif de recours médico secouriste;$.qualification.healthMotive;2.3;M19.02.00;Allergies;1.9;M90.11;Allergies;OK;OK;;;;;;
+Motif de recours médico secouriste;$.qualification.healthMotive;2.3;M19.02.01;Allergies avec gonflement du visage, du cou ou modification de la voix;1.9;M90.12;Allergies - Avec gonflement du visage, du cou, modification de la voix;OK;OK;;;;;;
+Motif de recours médico secouriste;$.qualification.healthMotive;2.3;M19.02.02;Allergies avec sensation de malaise / problème digestif;1.9;M90.13;Allergies - Avec sensation de malaise/problème digestif;OK;OK;;;;;;
+Motif de recours médico secouriste;$.qualification.healthMotive;2.3;M19.02.03;Allergies avec éruption généralisée;1.9;M90.14;Allergies - Avec éruption généralisée;OK;OK;;;;;;
+Motif de recours médico secouriste;$.qualification.healthMotive;2.3;M19.02.04;Allergies  avec perte de connaissance initiale ou altération de la inconscience;1.9;M90.16;Allergies - Avec perte de connaissance initiale ou inconscience;OK;OK;;;;;;
+Motif de recours médico secouriste;$.qualification.healthMotive;2.3;M19.02.05;Allergies avec difficultés respiratoires;1.9;M90.17;Allergies - Avec difficultés respiratoires;OK;OK;;;;;;
+Motif de recours médico secouriste;$.qualification.healthMotive;2.3;M19.02.06;Allergies sans signe de gravité;1.9;M90.19;Allergies - Allergie sans signe de gravité identifié;OK;OK;;;;;;
+Motif de recours médico secouriste;$.qualification.healthMotive;2.3;M19.03.00;Anomalie de la glycémie;1.9;M90.21;Anomalie de la glycémie;OK;OK;;;;;;
+Motif de recours médico secouriste;$.qualification.healthMotive;2.3;M19.04.00;Demande de conseil médical ou ordonnance;1.9;M90.31;Demande de conseil médical ou ordonnance;OK;OK;;;;;;
+Motif de recours médico secouriste;$.qualification.healthMotive;2.3;M19.05.00;Fièvre;1.9;M90.41;Fièvre;OK;OK;;;;;;
+Motif de recours médico secouriste;$.qualification.healthMotive;2.3;M19.06.00;Trouble digestif;1.9;M90.51;Trouble digestif;OK;OK;;;;;;
+Motif de recours médico secouriste;$.qualification.healthMotive;2.3;M19.06.01;Trouble digestif avec hémorragie digestive;1.9;M90.52;Trouble digestif - Avec hémorragie digestive;OK;OK;;;;;;
+Motif de recours médico secouriste;$.qualification.healthMotive;2.3;M19.06.02;Trouble digestif avec trouble du transit (diarrhée / vomissement);1.9;M90.53;Trouble digestif - Avec trouble digestif;OK;OK;;;;;;
+Motif de recours médico secouriste;$.qualification.healthMotive;2.3;M19.06.03;Problème de poche digestive;1.9;M90.54;Trouble digestif - Problème de poche digestive;OK;OK;;;;;;
+Motif de recours médico secouriste;$.qualification.healthMotive;2.3;M19.06.04;Trouble digestif sans douleur;1.9;M90.55;Trouble digestif - Sans douleur;OK;OK;;;;;;
+Motif de recours médico secouriste;$.qualification.healthMotive;2.3;M19.06.05;Troubles digestifs sans signe de gravité;1.9;M90.59;Trouble digestif - Troubles digestifs sans signe de gravité identifié;OK;OK;;;;;;
+Motif de recours médico secouriste;$.qualification.healthMotive;2.3;M19.07.00;Problème psychiatrique / social;1.9;M90.61;Problème psychiatrique / social;OK;OK;;;;;;
+Motif de recours médico secouriste;$.qualification.healthMotive;2.3;M19.07.01;Misère physiologique ou incurie;1.9;M90.62;Problème psychiatrique / social - Altération de l‘état général - misère physiologique et incurie;OK;OK;;;;;;
+Motif de recours médico secouriste;$.qualification.healthMotive;2.3;M19.07.02;Agitation / crise nerveuse / comportement violent;1.9;M90.63;Problème psychiatrique / social - Agitation, crise nerveuse, comportement violent;OK;OK;;;;;;
+Motif de recours médico secouriste;$.qualification.healthMotive;2.3;M19.07.03;Etat de manque / Sevrage;1.9;M90.64;Problème psychiatrique / social - Etat de manque - Sevrage;OK;OK;;;;;;
+Motif de recours médico secouriste;$.qualification.healthMotive;2.3;M19.07.04;Problème social ou sanitaire;1.9;M90.65;Problème psychiatrique / social - Problème social ou sanitaire;OK;OK;;;;;;
+Motif de recours médico secouriste;$.qualification.healthMotive;2.3;M19.08.00;Problème infectieux;1.9;M90.71;Problème infectieux;OK;OK;;;;;;
+Motif de recours médico secouriste;$.qualification.healthMotive;2.3;M20.00.00;Décès certain;1.9;M98.00;Décès certain;OK;OK;;;;;;
+Motif de recours médico secouriste;$.qualification.healthMotive;2.3;M20.01.00;Corps en décomposition;1.9;M98.01;Corps en décomposition;OK;OK;;;;;;
+Motif de recours médico secouriste;$.qualification.healthMotive;2.3;M20.02.00;Décés déclaré par un professionnel de santé;1.9;M98.11;Décés déclaré par un professionnel de santé;OK;OK;;;;;;
+Motif de recours médico secouriste;$.qualification.healthMotive;2.3;M20.03.00;Rigidité cadavérique et corps froid;1.9;M98.21;Rigidité cadavérique certaine au niveau des membres et corps froid;OK;OK;;;;;;
+Motif de recours médico secouriste;$.qualification.healthMotive;2.3;M20.04.00;Tête séparée du tronc;1.9;M98.31;Tête détachée;OK;OK;;;;;;
+Risque menace et sensibilité;$.qualification.riskThreat;1.9;R36;Discrimination raciale, religieuse, sexiste ou autre;2.3;;;OK;OK;A supprimmer (pas d'interet dans RMS);;;;;
+Risque menace et sensibilité;$.qualification.riskThreat;2.3;R17;Nuée d'insectes;1.9;R37;Situation instable/indéterminée;OK;OK;;;;;;
+Risque menace et sensibilité;$.qualification.riskThreat;2.3;R18;Inondation;1.9;R37;Situation instable/indéterminée;OK;OK;;;;;;
+Risque menace et sensibilité;$.qualification.riskThreat;2.3;R60;Risque d'explosion, présence de gaz (bouteilles);1.9;R13;Risque d'explosion, présence de gaz;OK;OK;;;;;;
+Risque menace et sensibilité;$.qualification.riskThreat;2.3;R61;Présence de matière ou matériel explosif;1.9;R13;Risque d'explosion, présence de gaz;OK;OK;;;;;;
+Risque menace et sensibilité;$.qualification.riskThreat;2.3;R62;GPL ou carburation non conventionnelle ;1.9;R13;Risque d'explosion, présence de gaz;OK;OK;;;;;;
+Risque menace et sensibilité;$.qualification.riskThreat;2.3;R63;Engin Propulsion / Traction électrique;1.9;R19;Risque électrique/ risque lié à une ligne HT ou THT;OK;OK;;;;;;
+Risque menace et sensibilité;$.qualification.riskThreat;2.3;R64;Levée de doute ou sinistre naissant;1.9;R37;Situation instable/indéterminée;OK;OK;;;;;;
+Risque menace et sensibilité;$.qualification.riskThreat;2.3;R65;Présence de bétail;1.9;R37;Situation instable/indéterminée;OK;OK;;;;;;
+Risque menace et sensibilité;$.qualification.riskThreat;2.3;R66;Présence d'animal domestique;1.9;R37;Situation instable/indéterminée;OK;OK;;;;;;
+Risque menace et sensibilité;$.qualification.riskThreat;2.3;R67;Porte/accès verrouillé;1.9;R37;Situation instable/indéterminée;OK;OK;;;;;;
+Risque menace et sensibilité;$.qualification.riskThreat;2.3;R68;Patient / victime ejecté;1.9;R37;Situation instable/indéterminée;OK;OK;;;;;;
+Risque menace et sensibilité;$.qualification.riskThreat;2.3;R69;Patient/Victime non visible;1.9;R37;Situation instable/indéterminée;OK;OK;;;;;;
+Risque menace et sensibilité;$.qualification.riskThreat;2.3;R70;Carence prestataire extérieur;1.9;R37;Situation instable/indéterminée;OK;OK;;;;;;
+Risque menace et sensibilité;$.qualification.riskThreat;2.3;R71;Situation en profondeur ;1.9;R37;Situation instable/indéterminée;OK;OK;;;;;;
+Risque menace et sensibilité;$.qualification.riskThreat;2.3;R72;Hauteur inférieure ou égale à 2 étages ( <= 8mètres);1.9;R37;Situation instable/indéterminée;OK;OK;;;;;;
+Risque menace et sensibilité;$.qualification.riskThreat;2.3;R73;Situation en milieu vicié;1.9;R37;Situation instable/indéterminée;OK;OK;;;;;;
+Risque menace et sensibilité;$.qualification.riskThreat;2.3;R74;Locaux à sommeil;1.9;R37;Situation instable/indéterminée;OK;OK;;;;;;
+Risque menace et sensibilité;$.qualification.riskThreat;2.3;R75;Gaz - Accident ou présence de travaux;1.9;R13;Risque d'explosion, présence de gaz;OK;OK;;;;;;
+Risque menace et sensibilité;$.qualification.riskThreat;2.3;R76;Gaz - Ouvrage endommagé visible;1.9;R13;Risque d'explosion, présence de gaz;OK;OK;;;;;;
+Risque menace et sensibilité;$.qualification.riskThreat;2.3;R77;Gaz - Ouvrage endommaé non visible;1.9;R13;Risque d'explosion, présence de gaz;OK;OK;;;;;;
+Risque menace et sensibilité;$.qualification.riskThreat;2.3;R78;Gaz - Dégâts apparents sur la conduite de gaz;1.9;R13;Risque d'explosion, présence de gaz;OK;OK;;;;;;
+Risque menace et sensibilité;$.qualification.riskThreat;2.3;R79;Gaz - Bruits, sifflements, souffle, vibrations ou projections;1.9;R13;Risque d'explosion, présence de gaz;OK;OK;;;;;;
+Risque menace et sensibilité;$.qualification.riskThreat;2.3;R80;Gaz - Zone dense en population;1.9;R13;Risque d'explosion, présence de gaz;OK;OK;;;;;;
+Risque menace et sensibilité;$.qualification.riskThreat;2.3;R81;Gaz - Grand rassemblement de public;1.9;R13;Risque d'explosion, présence de gaz;OK;OK;;;;;;
+Risque menace et sensibilité;$.qualification.riskThreat;2.3;R82;Gaz - En sous-sol;1.9;R13;Risque d'explosion, présence de gaz;OK;OK;;;;;;
+Risque menace et sensibilité;$.qualification.riskThreat;2.3;R83;Nombreux appels;1.9;R37;Situation instable/indéterminée;OK;OK;;;;;;
+Risque menace et sensibilité;$.qualification.riskThreat;2.3;R84;Hauteur supérieure à 2 étages (> 8 mètres);1.9;R37;Situation instable/indéterminée;OK;OK;;;;;;
+Risque menace et sensibilité;$.qualification.riskThreat;2.3;R85;Hauteur supérieure à 7 étages (> 28 mètres);1.9;R37;Situation instable/indéterminée;OK;OK;;;;;;
+Risque menace et sensibilité;$.qualification.riskThreat;2.3;R86;Voie non carrossable;1.9;R20;Difficulté d’accès sur site;OK;OK;;;;;;
+Risque menace et sensibilité;$.qualification.riskThreat;2.3;R88;Victime face à un danger immédiat;1.9;R37;Situation instable/indéterminée;OK;OK;;;;;;
+Risque menace et sensibilité;$.qualification.riskThreat;2.3;R89;Victime face à une menace plus ou moins différée;1.9;R37;Situation instable/indéterminée;OK;OK;;;;;;
+Risque menace et sensibilité;$.qualification.riskThreat;2.3;R90;Présence dans un lieu public non protégé ;1.9;R37;Situation instable/indéterminée;OK;OK;;;;;;
+Risque menace et sensibilité;$.qualification.riskThreat;2.3;R91;Implication d’une autorité;1.9;R25;Implication d’une personnalité;OK;OK;;;;;;
+Type de lieu;$.qualification.locationKind;1.9;L02.02.04;Hôtel sur autoroute;2.3;L02.02.03;Aire de repos ou de service sur voie rapide;OK;OK;;;;;;
+Type de lieu;$.qualification.locationKind;1.9;L02.03.03;Tunnel;2.3;L02.03.00;Voie ferrée/tramway/métro;OK;OK;;;;;;
+Type de lieu;$.qualification.locationKind;1.9;L02.06.07;CRNA;2.3;L02.06.00;Aéroport / aérodrome;OK;OK;;;;;;
+Type de lieu;$.qualification.locationKind;1.9;L02.06.08;PCZAR;2.3;L02.06.00;Aéroport / aérodrome;OK;OK;;;;;;
+Type de lieu;$.qualification.locationKind;1.9;L03.04.00;Lieu d’activité professionnelle collective, équipement lourds;2.3;L03.05.00;Autre local d’activité professionnelle;OK;OK;;;;;;
+Type de lieu;$.qualification.locationKind;1.9;L04.07.01;A l’intérieur;2.3;L04.07.00;Établissement de santé;OK;OK;;;;;;
+Type de lieu;$.qualification.locationKind;1.9;L04.07.02;A l’extérieur;2.3;L04.07.00;Établissement de santé;OK;OK;;;;;;
+Type de lieu;$.qualification.locationKind;1.9;L05.01.02;Prairie;2.3;L05.01.01;Champ / prairie;OK;OK;;;;;;
+Type de lieu;$.qualification.locationKind;1.9;L05.01.03;Milieu forestier, broussailles;2.3;L05.01.03;Milieu forestier;OK;OK;;;;;;
+Type de lieu;$.qualification.locationKind;1.9;L05.04.03;Port, quai, embarcadère;2.3;L05.04.00;Milieu maritime;OK;OK;;;;;;
+Type de lieu;$.qualification.locationKind;1.9;L07.01.00;Autre lieu d'intervention;2.3;L07.00.00;Lieu non explicite;OK;OK;;;;;;
+Type de lieu;$.qualification.locationKind;1.9;L07.01.01;Site sensible;2.3;L07.00.00;Lieu non explicite;OK;OK;;;;;;
+Type de lieu;$.qualification.locationKind;1.9;L07.02.00;Lieu indéterminé;2.3;L07.00.00;Lieu non explicite;OK;OK;;;;;;
+Type de lieu;$.qualification.locationKind;2.3;L01.01.05;Toiture/Combles d'une maison;1.9;L01.01.00;Maison particulière, pavillon;OK;OK;;;;;;
+Type de lieu;$.qualification.locationKind;2.3;L01.02.13;Local poubelle / vide ordure de l'immeuble;1.9;L01.02.00;Lieu d'habitation collectif ou foyer d'hébergement;OK;OK;;;;;;
+Type de lieu;$.qualification.locationKind;2.3;L01.02.14;Balcon/terrasse de l'immeuble;1.9;L01.02.00;Lieu d'habitation collectif ou foyer d'hébergement;OK;OK;;;;;;
+Type de lieu;$.qualification.locationKind;2.3;L01.03.04;Campement;1.9;L01.03.00;Habitat spécifique;OK;OK;;;;;;
+Type de lieu;$.qualification.locationKind;2.3;L01.03.05;Grande demeure / château / manoir;1.9;L01.03.00;Habitat spécifique;OK;OK;;;;;;
+Type de lieu;$.qualification.locationKind;2.3;L01.03.06;Chaumière;1.9;L01.03.00;Habitat spécifique;OK;OK;;;;;;
+Type de lieu;$.qualification.locationKind;2.3;L02.01.01;Tunnel sur voie publique (hors voie rapide);1.9;L02.02.05;Tunnel;OK;OK;;;;;;
+Type de lieu;$.qualification.locationKind;2.3;L02.01.02;Piste cyclable;1.9;L02.01.00;Voie publique hors voie rapide;OK;OK;;;;;;
+Type de lieu;$.qualification.locationKind;2.3;L02.01.03;Pont/viaduc sur voie publique (hors voie rapide);1.9;L02.01.00;Voie publique hors voie rapide;OK;OK;;;;;;
+Type de lieu;$.qualification.locationKind;2.3;L02.02.06;Pont/viaduc sur voie rapide;1.9;L02.02.00;Voie rapide;OK;OK;;;;;;
+Type de lieu;$.qualification.locationKind;2.3;L02.03.04;Pont/viaduc sur voie ferrée;1.9;L02.03.00;Voie ferrée;OK;OK;;;;;;
+Type de lieu;$.qualification.locationKind;2.3;L02.03.05;Passage à niveau;1.9;L02.03.00;Voie ferrée;OK;OK;;;;;;
+Type de lieu;$.qualification.locationKind;2.3;L02.04.01;Tunnel  (voie fluviale);1.9;L02.04.00;Voie fluviale;OK;OK;;;;;;
+Type de lieu;$.qualification.locationKind;2.3;L02.04.02;Ecluse;1.9;L02.04.00;Voie fluviale;OK;OK;;;;;;
+Type de lieu;$.qualification.locationKind;2.3;L02.06.09;Aéroport - Zone de sûreté à accès réglementé;1.9;L02.06.00;Aéroport / aérodrome;OK;OK;;;;;;
+Type de lieu;$.qualification.locationKind;2.3;L02.06.10;Base ou enceinte aérienne militaire;1.9;L02.06.00;Aéroport / aérodrome;OK;OK;;;;;;
+Type de lieu;$.qualification.locationKind;2.3;L02.07.04;Gare ou station souterraine;1.9;L02.07.00;Gare ferroviaire et routière;OK;OK;;;;;;
+Type de lieu;$.qualification.locationKind;2.3;L02.07.05;Gare ou station aérienne;1.9;L02.07.00;Gare ferroviaire et routière;OK;OK;;;;;;
+Type de lieu;$.qualification.locationKind;2.3;L02.07.06;Arrêt de bus / tramway;1.9;L02.07.00;Gare ferroviaire et routière;OK;OK;;;;;;
+Type de lieu;$.qualification.locationKind;2.3;L02.07.07;Voies de circulation de la gare;1.9;L02.07.00;Gare ferroviaire et routière;OK;OK;;;;;;
+Type de lieu;$.qualification.locationKind;2.3;L02.08.01;Pont hors aquatique;1.9;L02.01.00;Voie publique hors voie rapide;OK;OK;;;;;;
+Type de lieu;$.qualification.locationKind;2.3;L02.08.02;Pont aquatique mer;1.9;L02.04.00;Voie fluviale;OK;OK;;;;;;
+Type de lieu;$.qualification.locationKind;2.3;L02.08.03;Pont aquatique eaux intérieures;1.9;L02.04.00;Voie fluviale;OK;OK;;;;;;
+Type de lieu;$.qualification.locationKind;2.3;L02.09.00;Port/Quai/Embarcadère;1.9;L02.04.00;Voie fluviale;OK;OK;;;;;;
+Type de lieu;$.qualification.locationKind;2.3;L02.09.01;Port civil;1.9;L02.04.00;Voie fluviale;OK;OK;;;;;;
+Type de lieu;$.qualification.locationKind;2.3;L02.09.02;Port militaire;1.9;L02.04.00;Voie fluviale;OK;OK;;;;;;
+Type de lieu;$.qualification.locationKind;2.3;L03.02.01;Corps de ferme ;1.9;L03.02.00;Local agricole;OK;OK;;;;;;
+Type de lieu;$.qualification.locationKind;2.3;L03.02.02;Hangar agricole ;1.9;L03.02.00;Local agricole;OK;OK;;;;;;
+Type de lieu;$.qualification.locationKind;2.3;L04.06.06;Bibliothèque / médiathèque;1.9;L04.06.00;Espace évènementiel et/ou culturel;OK;OK;;;;;;
+Type de lieu;$.qualification.locationKind;2.3;L04.07.04;Etablissement de santé spécialisé;1.9;L04.07.00;Établissement de santé;OK;OK;;;;;;
+Type de lieu;$.qualification.locationKind;2.3;L04.07.05;Etablissement de santé (zone d'hospitalisation);1.9;L04.07.00;Établissement de santé;OK;OK;;;;;;
+Type de lieu;$.qualification.locationKind;2.3;L04.07.06;Établissement de santé (hors zone d'hospitalisation);1.9;L04.07.00;Établissement de santé;OK;OK;;;;;;
+Type de lieu;$.qualification.locationKind;2.3;L04.09.03;Autre établissement médico-social;1.9;L04.09.00;Établissement médico-social;OK;OK;;;;;;
+Type de lieu;$.qualification.locationKind;2.3;L04.11.05;Autre enceinte sportive;1.9;L04.11.00;Enceinte sportive;OK;OK;;;;;;
+Type de lieu;$.qualification.locationKind;2.3;L04.13.05;Centre de formation pour adulte;1.9;L04.13.00;Hébergement touristique;OK;OK;;;;;;
+Type de lieu;$.qualification.locationKind;2.3;L05.01.05;Espace naturel péri-urbain;1.9;L05.01.00;Plaine et campagne;OK;OK;;;;;;
+Type de lieu;$.qualification.locationKind;2.3;L05.01.03;Milieu forestier;1.9;L05.01.00;Plaine et campagne;OK;OK;;;;;;
+Type de lieu;$.qualification.locationKind;2.3;L05.01.04;Sous-bois;1.9;L05.01.00;Plaine et campagne;OK;OK;;;;;;
+Type de lieu;$.qualification.locationKind;2.3;L05.03.03;Eaux vives;1.9;L05.03.00;Milieu aquatique en eau douce;OK;OK;;;;;;
+Type de lieu;$.qualification.locationKind;2.3;L05.03.04;Zone de baignade en eau douce réglementée;1.9;L05.03.00;Milieu aquatique en eau douce;OK;OK;;;;;;
+Type de lieu;$.qualification.locationKind;2.3;L05.03.05;Plage / berge en eau douce;1.9;L05.03.00;Milieu aquatique en eau douce;OK;OK;;;;;;
+Type de lieu;$.qualification.locationKind;2.3;L05.04.07;Estran;1.9;L05.04.00;Milieu maritime;OK;OK;;;;;;
+Type de lieu;$.qualification.locationKind;2.3;L06.01.09;Lieu de stockage ou recyclage véhicules et engins divers;1.9;L06.01.00;Site industriel;OK;OK;;;;;;
+Type de lieu;$.qualification.locationKind;2.3;L06.01.10;Site de construction naval;1.9;L06.01.00;Site industriel;OK;OK;;;;;;
+Type de lieu;$.qualification.locationKind;2.3;L06.02.01;Ferme photovoltaïque;1.9;L06.02.00;Site de production transport d'énergie;OK;OK;;;;;;
+Type de lieu;$.qualification.locationKind;2.3;L06.02.02;Parc éolien;1.9;L06.02.00;Site de production transport d'énergie;OK;OK;;;;;;
+Type de lieu;$.qualification.locationKind;2.3;L06.02.03;Barrage hydraulique / retenue;1.9;L06.02.00;Site de production transport d'énergie;OK;OK;;;;;;
+Type de lieu;$.qualification.locationKind;2.3;L06.02.04;Poste de transformation électrique;1.9;L06.02.00;Site de production transport d'énergie;OK;OK;;;;;;
+Type de lieu;$.qualification.locationKind;2.3;L06.02.05;Ligne de transport d’électricité;1.9;L06.02.00;Site de production transport d'énergie;OK;OK;;;;;;
+Type de lieu;$.qualification.locationKind;2.3;L06.02.06;Centrale Thermique (gaz / charbon / biomasse);1.9;L06.02.00;Site de production transport d'énergie;OK;OK;;;;;;
+Type de lieu;$.qualification.locationKind;2.3;L06.02.07;Centre de méthanisation ;1.9;L06.02.00;Site de production transport d'énergie;OK;OK;;;;;;
+Type de lieu;$.qualification.locationKind;2.3;L06.02.08;Infrastructure de transport (Pipeline, Oléoduc, Gazoduc);1.9;L06.02.00;Site de production transport d'énergie;OK;OK;;;;;;
+Type de lieu;$.qualification.locationKind;2.3;L06.02.09;Poste de transformation gaz;1.9;L06.02.00;Site de production transport d'énergie;OK;OK;;;;;;
+Type de lieu;$.qualification.locationKind;2.3;L06.06.05;Centre en-Route de la Navigation Aérienne;1.9;L06.06.00;Administration publique;OK;OK;;;;;;
+Type de lieu;$.qualification.locationKind;2.3;L06.08.00;Station-service;1.9;L06.00.00;Zone ou site particulier;OK;OK;;;;;;
+Type de lieu;$.qualification.locationKind;2.3;L06.09.00;Site comportant des animaux;1.9;L06.00.00;Zone ou site particulier;OK;OK;;;;;;
+Type de lieu;$.qualification.locationKind;2.3;L06.09.01;Elevage d'animaux;1.9;L06.00.00;Zone ou site particulier;OK;OK;;;;;;
+Type de lieu;$.qualification.locationKind;2.3;L06.09.02;Haras / centre équestre / écuries;1.9;L06.00.00;Zone ou site particulier;OK;OK;;;;;;
+Type de lieu;$.qualification.locationKind;2.3;L06.09.03;Animalerie ou clinique vétérinaire;1.9;L06.00.00;Zone ou site particulier;OK;OK;;;;;;
+Type de lieu;$.qualification.locationKind;2.3;L06.10.00;Décharge / casse automobile;1.9;L06.00.00;Zone ou site particulier;OK;OK;;;;;;
+;;;;;;;;;;;;;;;
+;;;;;;;;;;;;;;;
+;;;;;;;;;;;;;;;
+;;;;;;;;;;;;;;;
+;;;;;;;;;;;;;;;
+;;;;;;;;;;;;;;;
+;;;;;;;;;;;;;;;
+;;;;;;;;;;;;;;;
+;;;;;;;;;;;;;;;
+;;;;;;;;;;;;;;;
+;;;;;;;;;;;;;;;
+;;;;;;;;;;;;;;;
+;;;;;;;;;;;;;;;
+;;;;;;;;;;;;;;;
+;;;;;;;;;;;;;;;
+;;;;;;;;;;;;;;;
+;;;;;;;;;;;;;;;
+;;;;;;;;;;;;;;;
+;;;;;;;;;;;;;;;
+;;;;;;;;;;;;;;;
+;;;;;;;;;;;;;;;
+;;;;;;;;;;;;;;;
+;;;;;;;;;;;;;;;
+;;;;;;;;;;;;;;;
+;;;;;;;;;;;;;;;
+;;;;;;;;;;;;;;;
+;;;;;;;;;;;;;;;
+;;;;;;;;;;;;;;;
+;;;;;;;;;;;;;;;
+;;;;;;;;;;;;;;;
+;;;;;;;;;;;;;;;
+;;;;;;;;;;;;;;;
+;;;;;;;;;;;;;;;
+;;;;;;;;;;;;;;;
+;;;;;;;;;;;;;;;
+;;;;;;;;;;;;;;;
+;;;;;;;;;;;;;;;
+;;;;;;;;;;;;;;;
+;;;;;;;;;;;;;;;
+;;;;;;;;;;;;;;;
+;;;;;;;;;;;;;;;
+;;;;;;;;;;;;;;;
+;;;;;;;;;;;;;;;
+;;;;;;;;;;;;;;;
+;;;;;;;;;;;;;;;
+;;;;;;;;;;;;;;;
+;;;;;;;;;;;;;;;
+;;;;;;;;;;;;;;;
+;;;;;;;;;;;;;;;
+;;;;;;;;;;;;;;;
+;;;;;;;;;;;;;;;
+;;;;;;;;;;;;;;;
+;;;;;;;;;;;;;;;
+;;;;;;;;;;;;;;;
+;;;;;;;;;;;;;;;
+;;;;;;;;;;;;;;;
+;;;;;;;;;;;;;;;
+;;;;;;;;;;;;;;;
+;;;;;;;;;;;;;;;
+;;;;;;;;;;;;;;;
+;;;;;;;;;;;;;;;
+;;;;;;;;;;;;;;;
+;;;;;;;;;;;;;;;
+;;;;;;;;;;;;;;;
+;;;;;;;;;;;;;;;
+;;;;;;;;;;;;;;;
+;;;;;;;;;;;;;;;
+;;;;;;;;;;;;;;;
+;;;;;;;;;;;;;;;
+;;;;;;;;;;;;;;;
+;;;;;;;;;;;;;;;
+;;;;;;;;;;;;;;;
+;;;;;;;;;;;;;;;
+;;;;;;;;;;;;;;;
+;;;;;;;;;;;;;;;
+;;;;;;;;;;;;;;;
+;;;;;;;;;;;;;;;
+;;;;;;;;;;;;;;;
+;;;;;;;;;;;;;;;
+;;;;;;;;;;;;;;;
+;;;;;;;;;;;;;;;
+;;;;;;;;;;;;;;;
+;;;;;;;;;;;;;;;
+;;;;;;;;;;;;;;;
+;;;;;;;;;;;;;;;
+;;;;;;;;;;;;;;;
+;;;;;;;;;;;;;;;
+;;;;;;;;;;;;;;;
+;;;;;;;;;;;;;;;
+;;;;;;;;;;;;;;;
+;;;;;;;;;;;;;;;
+;;;;;;;;;;;;;;;
+;;;;;;;;;;;;;;;
+;;;;;;;;;;;;;;;
+;;;;;;;;;;;;;;;
+;;;;;;;;;;;;;;;
+;;;;;;;;;;;;;;;
+;;;;;;;;;;;;;;;
+;;;;;;;;;;;;;;;
+;;;;;;;;;;;;;;;
+;;;;;;;;;;;;;;;
+;;;;;;;;;;;;;;;
+;;;;;;;;;;;;;;;
+;;;;;;;;;;;;;;;
+;;;;;;;;;;;;;;;
+;;;;;;;;;;;;;;;
+;;;;;;;;;;;;;;;
+;;;;;;;;;;;;;;;
+;;;;;;;;;;;;;;;
+;;;;;;;;;;;;;;;
+;;;;;;;;;;;;;;;
+;;;;;;;;;;;;;;;
+;;;;;;;;;;;;;;;
+;;;;;;;;;;;;;;;
+;;;;;;;;;;;;;;;

--- a/converter/scripts/generate_nomenclatures_maps.py
+++ b/converter/scripts/generate_nomenclatures_maps.py
@@ -42,13 +42,14 @@ Entry = dict[str, str]  # {"code": ..., "label": ...}
 def _read_rows(input_path: Path) -> list[dict[str, str | None]]:
     # utf-8-sig strips the leading BOM some spreadsheet tools add on CSV export.
     with input_path.open(encoding="utf-8-sig", newline="") as f:
-        reader = csv.DictReader(f)
+        reader = csv.DictReader(f, delimiter=";")
         # Empty CSV fields decode as "" (unlike empty xlsx cells, which are
         # None) — normalize them so a blank "Code à transmettre" still means
         # "no entry" rather than an empty-string code.
         return [
             {key: (value if value else None) for key, value in row.items()}
             for row in reader
+            if any(value for key, value in row.items() if key)
         ]
 
 

--- a/converter/scripts/generate_nomenclatures_maps.py
+++ b/converter/scripts/generate_nomenclatures_maps.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Generate CISU<->RS nomenclature maps from the mapping Excel file.
+"""Generate CISU<->RS nomenclature maps from the mapping CSV export.
 
 Produces n = x*y Python modules under converter/nomenclatures/, one per
 combination of direction (x) and balise (y). Each module exposes a MAP dict
@@ -8,12 +8,11 @@ keyed by the received code, valued by the {code, label} to transmit.
 
 from __future__ import annotations
 
+import csv
 import re
 import subprocess
 import sys
 from pathlib import Path
-
-from openpyxl import load_workbook
 
 # Protocol version codes as they appear in the "Version code reçu" / "Version
 # code transmis" columns. Update here if a protocol's version changes.
@@ -28,7 +27,9 @@ DIRECTIONS = {
 }
 
 DEFAULT_INPUT = (
-    Path(__file__).resolve().parent.parent / "resources" / "mapping_nomenclatures.xlsx"
+    Path(__file__).resolve().parent.parent
+    / "resources"
+    / "export_mapping_nomenclatures.csv"
 )
 DEFAULT_OUTPUT_DIR = (
     Path(__file__).resolve().parent.parent / "converter" / "nomenclatures"
@@ -39,26 +40,16 @@ Entry = dict[str, str]  # {"code": ..., "label": ...}
 
 
 def _read_rows(input_path: Path) -> list[dict[str, str | None]]:
-    workbook = load_workbook(input_path, read_only=True, data_only=True)
-    sheet = workbook.active
-    if sheet is None:
-        raise ValueError("Workbook contains no active worksheet")
-
-    raw_rows = list(sheet.iter_rows(values_only=True))
-    workbook.close()
-
-    header = [str(cell).strip() if cell is not None else "" for cell in raw_rows[0]]
-    rows = []
-    for raw_row in raw_rows[1:]:
-        if all(cell is None for cell in raw_row):
-            continue
-        row = {
-            header[i]: (None if cell is None else str(cell))
-            for i, cell in enumerate(raw_row)
-            if i < len(header)
-        }
-        rows.append(row)
-    return rows
+    # utf-8-sig strips the leading BOM some spreadsheet tools add on CSV export.
+    with input_path.open(encoding="utf-8-sig", newline="") as f:
+        reader = csv.DictReader(f)
+        # Empty CSV fields decode as "" (unlike empty xlsx cells, which are
+        # None) — normalize them so a blank "Code à transmettre" still means
+        # "no entry" rather than an empty-string code.
+        return [
+            {key: (value if value else None) for key, value in row.items()}
+            for row in reader
+        ]
 
 
 def _slug(balise: str) -> str:


### PR DESCRIPTION
## 🔎 Détails

- modification du script `generate_nomenclatures_maps.py`, qui prenait encore en entrée le fichier Excel, non versionné
- Correction d'une coquille sur une correspondance de nomenclature et regénération de la map associée
- Fixation du séparateur dans le script : la version précédente, basée sur `openpyxl`, utilisait le séparateur par défaut `,`. Les exports depuis la base documentaire utilisent les réglages par défaut de la zone géographique de l'organisation, donc `;`.
- Ajout d'un contrôle pour ignorer toutes les lignes vides ajoutées en bas du csv lors de l'export manuel.

